### PR TITLE
Use fixed paths for typescript SCSS imports

### DIFF
--- a/_template/style/index.tsx
+++ b/_template/style/index.tsx
@@ -1,1 +1,1 @@
-import './index.scss';
+import './_index.scss';

--- a/components/alert/style/index.tsx
+++ b/components/alert/style/index.tsx
@@ -1,1 +1,1 @@
-import './index.scss';
+import './_index.scss';

--- a/components/anchor/style/index.tsx
+++ b/components/anchor/style/index.tsx
@@ -1,3 +1,3 @@
-import './index.scss';
+import './_index.scss';
 
-import '../../sticky/style/index.scss';
+import '../../sticky/style/_index.scss';

--- a/components/aspect-ratio/style/index.tsx
+++ b/components/aspect-ratio/style/index.tsx
@@ -1,1 +1,1 @@
-import './index.scss';
+import './_index.scss';

--- a/components/avatar/style/index.tsx
+++ b/components/avatar/style/index.tsx
@@ -1,1 +1,1 @@
-import './index.scss';
+import './_index.scss';

--- a/components/back-top/style/index.tsx
+++ b/components/back-top/style/index.tsx
@@ -1,1 +1,1 @@
-import './index.scss';
+import './_index.scss';

--- a/components/badge/style/index.tsx
+++ b/components/badge/style/index.tsx
@@ -1,1 +1,1 @@
-import './index.scss';
+import './_index.scss';

--- a/components/breadcrumb/style/index.tsx
+++ b/components/breadcrumb/style/index.tsx
@@ -1,1 +1,1 @@
-import './index.scss';
+import './_index.scss';

--- a/components/button/style/index.tsx
+++ b/components/button/style/index.tsx
@@ -1,1 +1,1 @@
-import './index.scss';
+import './_index.scss';

--- a/components/calendar/style/index.tsx
+++ b/components/calendar/style/index.tsx
@@ -1,1 +1,1 @@
-import './index.scss';
+import './_index.scss';

--- a/components/card/style/index.tsx
+++ b/components/card/style/index.tsx
@@ -1,1 +1,1 @@
-import './index.scss';
+import './_index.scss';

--- a/components/carousel/style/index.tsx
+++ b/components/carousel/style/index.tsx
@@ -1,1 +1,1 @@
-import './index.scss';
+import './_index.scss';

--- a/components/checkbox/style/index.tsx
+++ b/components/checkbox/style/index.tsx
@@ -1,1 +1,1 @@
-import './index.scss';
+import './_index.scss';

--- a/components/collapse-transition/style/index.tsx
+++ b/components/collapse-transition/style/index.tsx
@@ -1,1 +1,1 @@
-import '../style/index.scss';
+import '../style/_index.scss';

--- a/components/collapse/style/index.tsx
+++ b/components/collapse/style/index.tsx
@@ -1,1 +1,1 @@
-import './index.scss';
+import './_index.scss';

--- a/components/date-picker/style/index.tsx
+++ b/components/date-picker/style/index.tsx
@@ -1,1 +1,1 @@
-import './index.scss';
+import './_index.scss';

--- a/components/descriptions/style/index.tsx
+++ b/components/descriptions/style/index.tsx
@@ -1,1 +1,1 @@
-import './index.scss';
+import './_index.scss';

--- a/components/divider/style/index.tsx
+++ b/components/divider/style/index.tsx
@@ -1,1 +1,1 @@
-import './index.scss';
+import './_index.scss';

--- a/components/drawer/style/index.tsx
+++ b/components/drawer/style/index.tsx
@@ -1,4 +1,4 @@
-import '../style/index.scss';
+import '../style/_index.scss';
 
 // style dependencies
-import '../../overlay/style/index.scss';
+import '../../overlay/style/_index.scss';

--- a/components/dropdown/style/index.tsx
+++ b/components/dropdown/style/index.tsx
@@ -1,4 +1,4 @@
-import './index.scss';
+import './_index.scss';
 
 // style dependency
-import '../../popup/style/index.scss';
+import '../../popup/style/_index.scss';

--- a/components/empty/style/index.tsx
+++ b/components/empty/style/index.tsx
@@ -1,1 +1,1 @@
-import './index.scss';
+import './_index.scss';

--- a/components/flip/style/index.tsx
+++ b/components/flip/style/index.tsx
@@ -1,1 +1,1 @@
-import './index.scss';
+import './_index.scss';

--- a/components/form/style/index.tsx
+++ b/components/form/style/index.tsx
@@ -1,3 +1,3 @@
-import './index.scss';
+import './_index.scss';
 
-import '../../transition/style/index.scss';
+import '../../transition/style/_index.scss';

--- a/components/grid/style/index.tsx
+++ b/components/grid/style/index.tsx
@@ -1,1 +1,1 @@
-import './index.scss';
+import './_index.scss';

--- a/components/icon/style/index.tsx
+++ b/components/icon/style/index.tsx
@@ -1,1 +1,1 @@
-import './index.scss';
+import './_index.scss';

--- a/components/image/style/index.tsx
+++ b/components/image/style/index.tsx
@@ -1,1 +1,1 @@
-import './index.scss';
+import './_index.scss';

--- a/components/input-number/style/index.tsx
+++ b/components/input-number/style/index.tsx
@@ -1,3 +1,3 @@
-import './index.scss';
+import './_index.scss';
 
-import '../../input/style/index.scss';
+import '../../input/style/_index.scss';

--- a/components/input-password/style/index.tsx
+++ b/components/input-password/style/index.tsx
@@ -1,3 +1,3 @@
-import './index.scss';
+import './_index.scss';
 
-import '../../input/style/index.scss';
+import '../../input/style/_index.scss';

--- a/components/input/style/index.tsx
+++ b/components/input/style/index.tsx
@@ -1,1 +1,1 @@
-import './index.scss';
+import './_index.scss';

--- a/components/keyboard/style/index.tsx
+++ b/components/keyboard/style/index.tsx
@@ -1,1 +1,1 @@
-import './index.scss';
+import './_index.scss';

--- a/components/layout/style/index.tsx
+++ b/components/layout/style/index.tsx
@@ -1,1 +1,1 @@
-import './index.scss';
+import './_index.scss';

--- a/components/link/style/index.tsx
+++ b/components/link/style/index.tsx
@@ -1,1 +1,1 @@
-import './index.scss';
+import './_index.scss';

--- a/components/loader/style/index.tsx
+++ b/components/loader/style/index.tsx
@@ -1,1 +1,1 @@
-import './index.scss';
+import './_index.scss';

--- a/components/loading-bar/style/index.tsx
+++ b/components/loading-bar/style/index.tsx
@@ -1,1 +1,1 @@
-import './index.scss';
+import './_index.scss';

--- a/components/menu/style/index.tsx
+++ b/components/menu/style/index.tsx
@@ -1,4 +1,4 @@
-import './index.scss';
+import './_index.scss';
 
-import '../../popup/style/index.scss';
-import '../../collapse-transition/style/index.scss';
+import '../../popup/style/_index.scss';
+import '../../collapse-transition/style/_index.scss';

--- a/components/message/style/index.tsx
+++ b/components/message/style/index.tsx
@@ -1,1 +1,1 @@
-import './index.scss';
+import './_index.scss';

--- a/components/modal/style/index.tsx
+++ b/components/modal/style/index.tsx
@@ -1,5 +1,5 @@
-import './index.scss';
+import './_index.scss';
 
 // style dependencies
-import '../../overlay/style/index.scss';
-import '../../button/style/index.scss';
+import '../../overlay/style/_index.scss';
+import '../../button/style/_index.scss';

--- a/components/native-select/style/index.tsx
+++ b/components/native-select/style/index.tsx
@@ -1,1 +1,1 @@
-import './index.scss';
+import './_index.scss';

--- a/components/notification/style/index.tsx
+++ b/components/notification/style/index.tsx
@@ -1,1 +1,1 @@
-import './index.scss';
+import './_index.scss';

--- a/components/overlay/style/index.tsx
+++ b/components/overlay/style/index.tsx
@@ -1,1 +1,1 @@
-import './index.scss';
+import './_index.scss';

--- a/components/pagination/style/index.tsx
+++ b/components/pagination/style/index.tsx
@@ -1,1 +1,1 @@
-import './index.scss';
+import './_index.scss';

--- a/components/pop-confirm/style/index.tsx
+++ b/components/pop-confirm/style/index.tsx
@@ -1,5 +1,5 @@
-import './index.scss';
+import './_index.scss';
 
 // style dependencies
-import '../../button/style/index.scss';
-import '../../popover/style/index.scss';
+import '../../button/style/_index.scss';
+import '../../popover/style/_index.scss';

--- a/components/popover/style/index.tsx
+++ b/components/popover/style/index.tsx
@@ -1,4 +1,4 @@
-import './index.scss';
+import './_index.scss';
 
 // style dependency
-import '../../popup/style/index.scss';
+import '../../popup/style/_index.scss';

--- a/components/popup/style/index.tsx
+++ b/components/popup/style/index.tsx
@@ -1,4 +1,4 @@
-import './index.scss';
+import './_index.scss';
 
 // style dependency
-import '../../popup/style/index.scss';
+import '../../popup/style/_index.scss';

--- a/components/progress/style/index.tsx
+++ b/components/progress/style/index.tsx
@@ -1,1 +1,1 @@
-import './index.scss';
+import './_index.scss';

--- a/components/radio/style/index.tsx
+++ b/components/radio/style/index.tsx
@@ -1,1 +1,1 @@
-import './index.scss';
+import './_index.scss';

--- a/components/rate/style/index.tsx
+++ b/components/rate/style/index.tsx
@@ -1,1 +1,1 @@
-import './index.scss';
+import './_index.scss';

--- a/components/result/style/index.tsx
+++ b/components/result/style/index.tsx
@@ -1,1 +1,1 @@
-import './index.scss';
+import './_index.scss';

--- a/components/scroll-indicator/style/index.tsx
+++ b/components/scroll-indicator/style/index.tsx
@@ -1,1 +1,1 @@
-import './index.scss';
+import './_index.scss';

--- a/components/select/style/index.tsx
+++ b/components/select/style/index.tsx
@@ -1,4 +1,4 @@
-import './index.scss';
+import './_index.scss';
 
-import '../../input/style/index.scss';
-import '../../popup/style/index.scss';
+import '../../input/style/_index.scss';
+import '../../popup/style/_index.scss';

--- a/components/skeleton/style/index.tsx
+++ b/components/skeleton/style/index.tsx
@@ -1,1 +1,1 @@
-import './index.scss';
+import './_index.scss';

--- a/components/slider/style/index.tsx
+++ b/components/slider/style/index.tsx
@@ -1,4 +1,4 @@
-import './index.scss';
+import './_index.scss';
 
 // style dependencies
-import '../../tooltip/style/index.scss';
+import '../../tooltip/style/_index.scss';

--- a/components/space/style/index.tsx
+++ b/components/space/style/index.tsx
@@ -1,1 +1,1 @@
-import './index.scss';
+import './_index.scss';

--- a/components/split-button/style/index.tsx
+++ b/components/split-button/style/index.tsx
@@ -1,5 +1,5 @@
-import './index.scss';
+import './_index.scss';
 
 // style dependency
-import '../../button/style/index.scss';
-import '../../dropdown/style/index.scss';
+import '../../button/style/_index.scss';
+import '../../dropdown/style/_index.scss';

--- a/components/split/style/index.tsx
+++ b/components/split/style/index.tsx
@@ -1,1 +1,1 @@
-import './index.scss';
+import './_index.scss';

--- a/components/steps/style/index.tsx
+++ b/components/steps/style/index.tsx
@@ -1,1 +1,1 @@
-import './index.scss';
+import './_index.scss';

--- a/components/sticky/style/index.tsx
+++ b/components/sticky/style/index.tsx
@@ -1,1 +1,1 @@
-import './index.scss';
+import './_index.scss';

--- a/components/strength-indicator/style/index.tsx
+++ b/components/strength-indicator/style/index.tsx
@@ -1,1 +1,1 @@
-import './index.scss';
+import './_index.scss';

--- a/components/switch/style/index.tsx
+++ b/components/switch/style/index.tsx
@@ -1,1 +1,1 @@
-import './index.scss';
+import './_index.scss';

--- a/components/tabs/style/index.tsx
+++ b/components/tabs/style/index.tsx
@@ -1,1 +1,1 @@
-import './index.scss';
+import './_index.scss';

--- a/components/tag/style/index.tsx
+++ b/components/tag/style/index.tsx
@@ -1,1 +1,1 @@
-import './index.scss';
+import './_index.scss';

--- a/components/textarea/style/index.tsx
+++ b/components/textarea/style/index.tsx
@@ -1,4 +1,4 @@
-import './index.scss';
+import './_index.scss';
 
 // style dependency
-import '../../input/style/index.scss';
+import '../../input/style/_index.scss';

--- a/components/time-picker/style/index.tsx
+++ b/components/time-picker/style/index.tsx
@@ -1,1 +1,1 @@
-import './index.scss';
+import './_index.scss';

--- a/components/timeline/style/index.tsx
+++ b/components/timeline/style/index.tsx
@@ -1,1 +1,1 @@
-import './index.scss';
+import './_index.scss';

--- a/components/tooltip/style/index.tsx
+++ b/components/tooltip/style/index.tsx
@@ -1,4 +1,4 @@
-import './index.scss';
+import './_index.scss';
 
 // style dependency
-import '../../popover/style/index.scss';
+import '../../popover/style/_index.scss';

--- a/components/transfer/style/index.tsx
+++ b/components/transfer/style/index.tsx
@@ -1,6 +1,6 @@
-import './index.scss';
+import './_index.scss';
 
-import '../../button/style/index.scss';
-import '../../checkbox/style/index.scss';
-import '../../empty/style/index.scss';
-import '../../input/style/index.scss';
+import '../../button/style/_index.scss';
+import '../../checkbox/style/_index.scss';
+import '../../empty/style/_index.scss';
+import '../../input/style/_index.scss';

--- a/components/transition/style/index.tsx
+++ b/components/transition/style/index.tsx
@@ -1,1 +1,1 @@
-import './index.scss';
+import './_index.scss';

--- a/components/tree/style/index.tsx
+++ b/components/tree/style/index.tsx
@@ -1,4 +1,4 @@
-import './index.scss';
+import './_index.scss';
 
-import '../../checkbox/style/index.scss';
-import '../../collapse-transition/style/index.scss';
+import '../../checkbox/style/_index.scss';
+import '../../collapse-transition/style/_index.scss';

--- a/components/typography/style/index.tsx
+++ b/components/typography/style/index.tsx
@@ -1,1 +1,1 @@
-import './index.scss';
+import './_index.scss';

--- a/components/upload/style/index.tsx
+++ b/components/upload/style/index.tsx
@@ -1,4 +1,4 @@
-import './index.scss';
+import './_index.scss';
 
 // dependencies
 import '../../progress/style';


### PR DESCRIPTION
Hello there. First of all, great kit! I have been looking for something like this for a while.

Secondly, the [modularized imports](https://tiny-ui.dev/guide/get-started#use-modularized-tiny-ui) don't work correctly with (at least) the Parcel and Vite bundler. It cannot find the partial SCSS files, as typescript has no notion of that and does not look for the underscore. This PR updates the import paths in the style Typescript files, to use the actual file paths.