### PR TITLE
fix(react): restore intrinsic HTML props under React 19 types

### DIFF
--- a/.changeset/react-19-types-compat.md
+++ b/.changeset/react-19-types-compat.md
@@ -1,0 +1,5 @@
+---
+'@tiny-design/react': patch
+---
+
+Fix TypeScript compatibility with React 19. Component prop interfaces used the pattern `React.PropsWithRef<JSX.IntrinsicElements['x']>`, which relied on a globally-augmented `JSX` namespace that `@types/react@19` no longer provides. The resolved prop types collapsed to `any`, silently dropping every intrinsic HTML attribute (`onClick`, `type`, `disabled`, `aria-*`, `children`, etc.) for consumers on React 19. Replaced the pattern with `React.ComponentProps<'x'>` / `React.ComponentPropsWithoutRef<'x'>` across ~60 component type files. Works on React 18 and 19.

--- a/packages/react/REFS.md
+++ b/packages/react/REFS.md
@@ -1,0 +1,25 @@
+# Ref Conventions
+
+This package treats `ref` as an explicit component capability, not an accidental side effect of inheriting DOM props.
+
+## Rules
+
+- Use `React.ComponentPropsWithoutRef<'tag'>` for DOM-derived prop interfaces by default.
+- Only expose `ref` when the component intentionally supports DOM access through `React.forwardRef`.
+- Do not rely on `React.ComponentProps<'tag'>` to leak `ref` into props interfaces.
+- If a component is primarily compositional or layout-only, do not expose `ref` unless there is a concrete DOM integration need.
+
+## Components That Should Expose `ref`
+
+- Interactive controls and focus targets such as `Button`, `Input`, `NativeSelect`, `Link`, `Switch`, `Checkbox`, `Radio`.
+- Components frequently used for measurement, scrolling, positioning, or animation integration such as `Tree`, `Slider`, `Grid`, `Space`, `Flex`, `Layout`, `Anchor`, `Waterfall`, `Transfer`, `Steps`, and typography primitives.
+
+## Components That Usually Should Not Expose `ref`
+
+- Grouping or compositional wrappers such as `Button.Group`, `Checkbox.Group`, `Radio.Group`, `Input.Group`, `Input.Addon`, `Form.Item`, `Descriptions`, `Descriptions.Item`.
+
+## Practical Guidance
+
+- If consumers need the outer wrapper and an inner native control, expose both intentionally, for example `Checkbox` plus `checkboxRef`, or `Radio` plus `radioRef`.
+- If a component renders different DOM elements by state, make the forwarded ref type reflect that reality instead of pretending it always points to one tag.
+- When adding a new forwarded ref, add a focused test that proves the ref resolves to the expected DOM node.

--- a/packages/react/src/alert/types.ts
+++ b/packages/react/src/alert/types.ts
@@ -5,7 +5,7 @@ export type AlertType = 'success' | 'info' | 'warning' | 'error';
 
 export interface AlertProps
   extends BaseProps,
-    Omit<React.PropsWithoutRef<JSX.IntrinsicElements['div']>, 'title'> {
+    Omit<React.ComponentPropsWithoutRef<'div'>, 'title'> {
   /** alert title */
   title?: string | ReactNode;
 

--- a/packages/react/src/anchor/__tests__/anchor.test.tsx
+++ b/packages/react/src/anchor/__tests__/anchor.test.tsx
@@ -32,4 +32,16 @@ describe('<Anchor />', () => {
     expect(getByText('Link 1')).toBeInTheDocument();
     expect(getByText('Link 2')).toBeInTheDocument();
   });
+
+  it('should forward ref to root list element', () => {
+    const ref = React.createRef<HTMLUListElement>();
+
+    render(
+      <Anchor ref={ref}>
+        <Anchor.Link href="#section1" title="Section 1" />
+      </Anchor>
+    );
+
+    expect(ref.current).toBeInstanceOf(HTMLUListElement);
+  });
 });

--- a/packages/react/src/anchor/anchor.tsx
+++ b/packages/react/src/anchor/anchor.tsx
@@ -7,7 +7,20 @@ import { AnchorLinkProps, AnchorProps } from './types';
 import { AnchorContext } from './anchor-context';
 import Sticky from '../sticky';
 
-const Anchor = (props: AnchorProps): JSX.Element => {
+function assignRef<T>(ref: React.Ref<T> | undefined, value: T | null): void {
+  if (!ref) {
+    return;
+  }
+
+  if (typeof ref === 'function') {
+    ref(value);
+    return;
+  }
+
+  (ref as React.MutableRefObject<T | null>).current = value;
+}
+
+const Anchor = React.forwardRef<HTMLUListElement, AnchorProps>((props, ref): JSX.Element => {
   const {
     affix = false,
     offsetTop = 0,
@@ -20,6 +33,7 @@ const Anchor = (props: AnchorProps): JSX.Element => {
     style,
     children,
     prefixCls: customisedCls,
+    ...otherProps
   } = props;
   const configContext = useContext(ConfigContext);
   const prefixCls = getPrefixCls('anchor', configContext.prefixCls, customisedCls);
@@ -36,6 +50,14 @@ const Anchor = (props: AnchorProps): JSX.Element => {
   const unregisterLink = useCallback((href: string) => {
     linksRef.current.delete(href);
   }, []);
+
+  const setAnchorNode = useCallback(
+    (node: HTMLUListElement | null) => {
+      anchorRef.current = node;
+      assignRef(ref, node);
+    },
+    [ref]
+  );
 
   const updateInk = useCallback(() => {
     const anchorEl = anchorRef.current;
@@ -200,7 +222,7 @@ const Anchor = (props: AnchorProps): JSX.Element => {
   );
 
   const anchorContent = (
-    <ul className={cls} style={style} ref={anchorRef}>
+    <ul {...otherProps} className={cls} style={style} ref={setAnchorNode}>
       <div className={`${prefixCls}__ink`}>
         <div className={`${prefixCls}__ink-ball`} ref={inkBallRef} />
       </div>
@@ -228,7 +250,7 @@ const Anchor = (props: AnchorProps): JSX.Element => {
       )}
     </AnchorContext.Provider>
   );
-};
+});
 
 Anchor.displayName = 'Anchor';
 

--- a/packages/react/src/anchor/types.ts
+++ b/packages/react/src/anchor/types.ts
@@ -1,7 +1,9 @@
 import React from 'react';
 import { BaseProps } from '../_utils/props';
 
-export interface AnchorProps extends BaseProps {
+export interface AnchorProps
+  extends BaseProps,
+    Omit<React.ComponentPropsWithoutRef<'ul'>, 'children' | 'onChange' | 'onClick'> {
   affix?: boolean;
   type?: 'dot' | 'line';
   offsetBottom?: number;

--- a/packages/react/src/anchor/types.ts
+++ b/packages/react/src/anchor/types.ts
@@ -12,7 +12,7 @@ export interface AnchorProps extends BaseProps {
   children?: React.ReactNode;
 }
 
-export interface AnchorLinkProps extends BaseProps, React.PropsWithRef<JSX.IntrinsicElements['a']> {
+export interface AnchorLinkProps extends BaseProps, React.ComponentProps<'a'> {
   href: string;
   title: string;
   children?: React.ReactElement<AnchorLinkProps>[];

--- a/packages/react/src/anchor/types.ts
+++ b/packages/react/src/anchor/types.ts
@@ -12,7 +12,7 @@ export interface AnchorProps extends BaseProps {
   children?: React.ReactNode;
 }
 
-export interface AnchorLinkProps extends BaseProps, React.ComponentProps<'a'> {
+export interface AnchorLinkProps extends BaseProps, React.ComponentPropsWithoutRef<'a'> {
   href: string;
   title: string;
   children?: React.ReactElement<AnchorLinkProps>[];

--- a/packages/react/src/aspect-ratio/types.ts
+++ b/packages/react/src/aspect-ratio/types.ts
@@ -3,7 +3,7 @@ import { BaseProps } from '../_utils/props';
 
 export interface AspectRatioProps
   extends BaseProps,
-    React.PropsWithoutRef<JSX.IntrinsicElements['div']> {
+    React.ComponentPropsWithoutRef<'div'> {
   /** the width of the content */
   width?: number | string;
 

--- a/packages/react/src/avatar/types.ts
+++ b/packages/react/src/avatar/types.ts
@@ -6,7 +6,7 @@ export type AvatarPresence = 'online' | 'busy' | 'away' | 'offline';
 
 export interface AvatarProps
   extends BaseProps,
-    React.PropsWithoutRef<JSX.IntrinsicElements['span']> {
+    React.ComponentPropsWithoutRef<'span'> {
   /** use an icon */
   icon?: React.ReactNode;
 
@@ -28,7 +28,7 @@ export interface AvatarProps
 
 export interface AvatarGroupProps
   extends BaseProps,
-    React.PropsWithoutRef<JSX.IntrinsicElements['span']> {
+    React.ComponentPropsWithoutRef<'span'> {
   /** the distance between two avatars */
   gap: number | string;
 }

--- a/packages/react/src/badge/types.ts
+++ b/packages/react/src/badge/types.ts
@@ -3,7 +3,7 @@ import { BaseProps } from '../_utils/props';
 
 export interface BadgeProps
   extends BaseProps,
-    React.PropsWithoutRef<JSX.IntrinsicElements['span']> {
+    React.ComponentPropsWithoutRef<'span'> {
   /** the number to show in badge */
   count?: React.ReactNode;
 

--- a/packages/react/src/breadcrumb/types.ts
+++ b/packages/react/src/breadcrumb/types.ts
@@ -3,14 +3,14 @@ import { BaseProps } from '../_utils/props';
 
 export interface BreadcrumbProps
   extends BaseProps,
-    React.PropsWithoutRef<JSX.IntrinsicElements['nav']> {
+    React.ComponentPropsWithoutRef<'nav'> {
   separator?: React.ReactNode;
   children: ReactElement<BreadcrumbItemProps> | ReactElement<BreadcrumbItemProps>[];
 }
 
 export interface BreadcrumbItemProps
   extends BaseProps,
-    React.PropsWithoutRef<JSX.IntrinsicElements['li']> {
+    React.ComponentPropsWithoutRef<'li'> {
   separator?: React.ReactNode;
   children?: React.ReactNode;
 }

--- a/packages/react/src/button/button-group.tsx
+++ b/packages/react/src/button/button-group.tsx
@@ -8,76 +8,74 @@ import { BUTTON_MARK } from './button';
 
 const hasOwnProp = <T extends object>(props: T, key: keyof T): boolean => props[key] !== undefined;
 
-const ButtonGroup = React.forwardRef<HTMLDivElement, ButtonGroupProps>(
-  (props: ButtonGroupProps, ref) => {
-    const {
-      size = 'md',
-      variant = 'solid',
-      color = 'default',
-      disabled = false,
-      round = false,
-      shape,
-      inheritMode = 'fill',
-      prefixCls: customisedCls,
-      className,
-      children,
-      ...otherProps
-    } = props;
-    const configContext = useContext(ConfigContext);
-    const prefixCls = getPrefixCls('btn-group', configContext.prefixCls, customisedCls);
-    const btnSize = props.size || configContext.componentSize || size;
-    const resolvedShape = shape || (round ? 'round' : 'default');
-    const cls = classNames(
-      prefixCls,
-      {
-        [`${prefixCls}_round`]: resolvedShape === 'round',
-        [`${prefixCls}_variant-${variant}`]: variant,
-        [`${prefixCls}_color-${color}`]: color,
-        [`${prefixCls}_${btnSize}`]: btnSize,
-      },
-      className
-    );
-    return (
-      <div {...otherProps} className={cls} ref={ref}>
-        {React.Children.map(children, (child) => {
-          if (!React.isValidElement<ButtonProps>(child)) {
-            return child;
+const ButtonGroup = (props: ButtonGroupProps): React.ReactElement => {
+  const {
+    size = 'md',
+    variant = 'solid',
+    color = 'default',
+    disabled = false,
+    round = false,
+    shape,
+    inheritMode = 'fill',
+    prefixCls: customisedCls,
+    className,
+    children,
+    ...otherProps
+  } = props;
+  const configContext = useContext(ConfigContext);
+  const prefixCls = getPrefixCls('btn-group', configContext.prefixCls, customisedCls);
+  const btnSize = props.size || configContext.componentSize || size;
+  const resolvedShape = shape || (round ? 'round' : 'default');
+  const cls = classNames(
+    prefixCls,
+    {
+      [`${prefixCls}_round`]: resolvedShape === 'round',
+      [`${prefixCls}_variant-${variant}`]: variant,
+      [`${prefixCls}_color-${color}`]: color,
+      [`${prefixCls}_${btnSize}`]: btnSize,
+    },
+    className
+  );
+  return (
+    <div {...otherProps} className={cls}>
+      {React.Children.map(children, (child) => {
+        if (!React.isValidElement<ButtonProps>(child)) {
+          return child;
+        }
+
+        const childType = child.type as unknown as Record<PropertyKey, unknown>;
+        if (!childType[BUTTON_MARK]) {
+          return child;
+        }
+
+        if (inheritMode === 'none') {
+          return child;
+        }
+
+        const childProps: Partial<ButtonProps> = {};
+        const applyProp = <K extends keyof ButtonProps>(key: K, value: ButtonProps[K]): void => {
+          if (inheritMode === 'override' || !hasOwnProp(child.props, key)) {
+            childProps[key] = value;
           }
+        };
 
-          const childType = child.type as Record<PropertyKey, unknown>;
-          if (!childType[BUTTON_MARK]) {
-            return child;
-          }
+        applyProp('variant', variant as ButtonVariant);
+        applyProp('color', color as ButtonColor);
+        applyProp('size', btnSize as SizeType);
+        applyProp('disabled', disabled);
 
-          if (inheritMode === 'none') {
-            return child;
-          }
+        if (
+          inheritMode === 'override' ||
+          (!hasOwnProp(child.props, 'shape') && !hasOwnProp(child.props, 'round'))
+        ) {
+          childProps.shape = resolvedShape as ButtonShape;
+        }
 
-          const childProps: Partial<ButtonProps> = {};
-          const applyProp = <K extends keyof ButtonProps>(key: K, value: ButtonProps[K]): void => {
-            if (inheritMode === 'override' || !hasOwnProp(child.props, key)) {
-              childProps[key] = value;
-            }
-          };
-
-          applyProp('variant', variant as ButtonVariant);
-          applyProp('color', color as ButtonColor);
-          applyProp('size', btnSize as SizeType);
-          applyProp('disabled', disabled);
-
-          if (
-            inheritMode === 'override' ||
-            (!hasOwnProp(child.props, 'shape') && !hasOwnProp(child.props, 'round'))
-          ) {
-            childProps.shape = resolvedShape as ButtonShape;
-          }
-
-          return React.cloneElement(child, childProps);
-        })}
-      </div>
-    );
-  }
-);
+        return React.cloneElement(child, childProps);
+      })}
+    </div>
+  );
+};
 
 ButtonGroup.displayName = 'ButtonGroup';
 

--- a/packages/react/src/button/button.tsx
+++ b/packages/react/src/button/button.tsx
@@ -5,6 +5,7 @@ import { getPrefixCls } from '../_utils/general';
 import { ButtonProps } from './types';
 
 export const BUTTON_MARK = Symbol('tiny-design.button');
+const isProduction = (globalThis as { process?: { env?: { NODE_ENV?: string } } }).process?.env?.NODE_ENV === 'production';
 
 const Button = React.forwardRef<HTMLButtonElement, ButtonProps>((props: ButtonProps, ref) => {
   const {
@@ -37,7 +38,7 @@ const Button = React.forwardRef<HTMLButtonElement, ButtonProps>((props: ButtonPr
   const accessibleName =
     otherProps['aria-label'] || otherProps['aria-labelledby'] || otherProps.title;
 
-  if (process.env.NODE_ENV !== 'production' && isIconOnly && !accessibleName) {
+  if (!isProduction && isIconOnly && !accessibleName) {
     // Icon-only buttons need an accessible name.
     console.warn(
       'Button with icon only should provide `aria-label`, `aria-labelledby`, or `title`.'

--- a/packages/react/src/button/types.ts
+++ b/packages/react/src/button/types.ts
@@ -12,7 +12,7 @@ export type ButtonIconPosition = 'start' | 'end';
 export type ButtonGroupInheritMode = 'fill' | 'override' | 'none';
 
 export interface ButtonProps
-  extends BaseProps, React.ComponentProps<'button'> {
+  extends BaseProps, React.ComponentPropsWithoutRef<'button'> {
   variant?: ButtonVariant;
   color?: ButtonColor;
   loading?: boolean;
@@ -27,7 +27,7 @@ export interface ButtonProps
 }
 
 export interface ButtonGroupProps
-  extends BaseProps, React.ComponentProps<'div'> {
+  extends BaseProps, React.ComponentPropsWithoutRef<'div'> {
   variant?: ButtonVariant;
   color?: ButtonColor;
   size?: SizeType;

--- a/packages/react/src/button/types.ts
+++ b/packages/react/src/button/types.ts
@@ -12,7 +12,7 @@ export type ButtonIconPosition = 'start' | 'end';
 export type ButtonGroupInheritMode = 'fill' | 'override' | 'none';
 
 export interface ButtonProps
-  extends BaseProps, React.PropsWithRef<JSX.IntrinsicElements['button']> {
+  extends BaseProps, React.ComponentProps<'button'> {
   variant?: ButtonVariant;
   color?: ButtonColor;
   loading?: boolean;
@@ -27,7 +27,7 @@ export interface ButtonProps
 }
 
 export interface ButtonGroupProps
-  extends BaseProps, React.PropsWithRef<JSX.IntrinsicElements['div']> {
+  extends BaseProps, React.ComponentProps<'div'> {
   variant?: ButtonVariant;
   color?: ButtonColor;
   size?: SizeType;

--- a/packages/react/src/calendar/types.ts
+++ b/packages/react/src/calendar/types.ts
@@ -7,7 +7,7 @@ export type SelectionMode = 'single' | 'range' | 'multiple';
 
 export interface CalendarProps
   extends BaseProps,
-    Omit<React.PropsWithoutRef<JSX.IntrinsicElements['div']>, 'onChange' | 'onSelect' | 'defaultValue'> {
+    Omit<React.ComponentPropsWithoutRef<'div'>, 'onChange' | 'onSelect' | 'defaultValue'> {
   /** Selected date (controlled, single mode) */
   defaultValue?: Date;
   /** Controlled selected date */

--- a/packages/react/src/card/types.ts
+++ b/packages/react/src/card/types.ts
@@ -3,14 +3,14 @@ import { BaseProps } from '../_utils/props';
 
 export type CardVariant = 'outlined' | 'elevated' | 'filled';
 
-export interface CardContentProps extends React.PropsWithoutRef<JSX.IntrinsicElements['div']> {
+export interface CardContentProps extends React.ComponentPropsWithoutRef<'div'> {
   prefixCls?: string;
   children: ReactNode;
 }
 
 export interface CardProps
   extends BaseProps,
-    Omit<React.PropsWithoutRef<JSX.IntrinsicElements['div']>, 'title'> {
+    Omit<React.ComponentPropsWithoutRef<'div'>, 'title'> {
   title?: ReactNode;
   extra?: ReactNode;
   /** Card surface style */

--- a/packages/react/src/cascader/types.ts
+++ b/packages/react/src/cascader/types.ts
@@ -13,7 +13,7 @@ export type CascaderValue = (string | number)[];
 
 export interface CascaderProps
   extends BaseProps,
-    Omit<React.PropsWithoutRef<JSX.IntrinsicElements['div']>, 'onChange' | 'defaultValue'> {
+    Omit<React.ComponentPropsWithoutRef<'div'>, 'onChange' | 'defaultValue'> {
   options: CascaderOption[];
   value?: CascaderValue;
   defaultValue?: CascaderValue;

--- a/packages/react/src/checkbox/checkbox-group.tsx
+++ b/packages/react/src/checkbox/checkbox-group.tsx
@@ -5,53 +5,51 @@ import { getPrefixCls } from '../_utils/general';
 import { CheckboxGroupContext } from './checkbox-group-context';
 import { CheckboxGroupProps } from './types';
 
-const CheckboxGroup = React.forwardRef<HTMLDivElement, CheckboxGroupProps>(
-  (props: CheckboxGroupProps, ref): React.ReactElement => {
-    const {
-      defaultValue = [],
-      prefixCls: customisedCls,
-      onChange,
-      disabled,
-      className,
-      children,
-      ...otherProps
-    } = props;
-    const configContext = useContext(ConfigContext);
-    const prefixCls = getPrefixCls('checkbox-group', configContext.prefixCls, customisedCls);
-    const cls = classNames(prefixCls, className);
-    const [value, setValue] = useState<string[]>(
-      'value' in props ? (props.value as string[]) : defaultValue
-    );
+const CheckboxGroup = (props: CheckboxGroupProps): React.ReactElement => {
+  const {
+    defaultValue = [],
+    prefixCls: customisedCls,
+    onChange,
+    disabled,
+    className,
+    children,
+    ...otherProps
+  } = props;
+  const configContext = useContext(ConfigContext);
+  const prefixCls = getPrefixCls('checkbox-group', configContext.prefixCls, customisedCls);
+  const cls = classNames(prefixCls, className);
+  const [value, setValue] = useState<string[]>(
+    'value' in props ? (props.value as string[]) : defaultValue
+  );
 
-    const itemOnChange = (e: React.ChangeEvent<HTMLInputElement>): void => {
-      if (!disabled) {
-        const name = e.currentTarget.name;
-        const newValue = value.includes(name)
-          ? value.filter((v) => v !== name)
-          : [...value, name];
-        !('value' in props) && setValue(newValue);
-        onChange && onChange(newValue);
-      }
-    };
+  const itemOnChange = (e: React.ChangeEvent<HTMLInputElement>): void => {
+    if (!disabled) {
+      const name = e.currentTarget.name;
+      const newValue = value.includes(name)
+        ? value.filter((v) => v !== name)
+        : [...value, name];
+      !('value' in props) && setValue(newValue);
+      onChange && onChange(newValue);
+    }
+  };
 
-    useEffect(() => {
-      'value' in props && setValue([...(props.value as string[])]);
-    }, [props]);
+  useEffect(() => {
+    'value' in props && setValue([...(props.value as string[])]);
+  }, [props]);
 
-    return (
-      <CheckboxGroupContext.Provider
-        value={{
-          value,
-          disabled,
-          onChange: itemOnChange,
-        }}>
-        <div {...otherProps} ref={ref} role="group" className={cls}>
-          {children}
-        </div>
-      </CheckboxGroupContext.Provider>
-    );
-  }
-);
+  return (
+    <CheckboxGroupContext.Provider
+      value={{
+        value,
+        disabled,
+        onChange: itemOnChange,
+      }}>
+      <div {...otherProps} role="group" className={cls}>
+        {children}
+      </div>
+    </CheckboxGroupContext.Provider>
+  );
+};
 
 CheckboxGroup.displayName = 'CheckboxGroup';
 

--- a/packages/react/src/checkbox/types.ts
+++ b/packages/react/src/checkbox/types.ts
@@ -3,7 +3,7 @@ import { BaseProps } from '../_utils/props';
 
 export interface CheckboxGroupProps
   extends BaseProps,
-    Omit<React.ComponentProps<'div'>, 'onChange'> {
+    Omit<React.ComponentPropsWithoutRef<'div'>, 'onChange'> {
   defaultValue?: string[];
   value?: string[];
   onChange?: (checkedValues: string[]) => void;
@@ -13,7 +13,7 @@ export interface CheckboxGroupProps
 
 export interface CheckboxProps
   extends BaseProps,
-    Omit<React.ComponentProps<'label'>, 'onChange'> {
+    Omit<React.ComponentPropsWithoutRef<'label'>, 'onChange'> {
   /** Only required when use checkbox group */
   value?: string;
   defaultChecked?: boolean;

--- a/packages/react/src/checkbox/types.ts
+++ b/packages/react/src/checkbox/types.ts
@@ -3,7 +3,7 @@ import { BaseProps } from '../_utils/props';
 
 export interface CheckboxGroupProps
   extends BaseProps,
-    Omit<React.PropsWithRef<JSX.IntrinsicElements['div']>, 'onChange'> {
+    Omit<React.ComponentProps<'div'>, 'onChange'> {
   defaultValue?: string[];
   value?: string[];
   onChange?: (checkedValues: string[]) => void;
@@ -13,7 +13,7 @@ export interface CheckboxGroupProps
 
 export interface CheckboxProps
   extends BaseProps,
-    Omit<React.PropsWithRef<JSX.IntrinsicElements['label']>, 'onChange'> {
+    Omit<React.ComponentProps<'label'>, 'onChange'> {
   /** Only required when use checkbox group */
   value?: string;
   defaultChecked?: boolean;

--- a/packages/react/src/collapse/collapse-panel.tsx
+++ b/packages/react/src/collapse/collapse-panel.tsx
@@ -2,12 +2,7 @@ import React, { useEffect, useId, useState } from 'react';
 import classNames from 'classnames';
 import { ArrowDown } from '../_utils/components';
 import CollapseTransition from '../collapse-transition';
-import {
-  CollapseCollapsible,
-  CollapseExpandIconRender,
-  CollapseItem,
-  CollapseRenderState,
-} from './types';
+import { CollapseCollapsible, CollapseExpandIconRender, CollapseItem, CollapseRenderState } from './types';
 
 type CollapsePanelProps = {
   prefixCls: string;
@@ -28,10 +23,10 @@ type CollapsePanelProps = {
   onToggle: (key: string, event: React.MouseEvent) => void;
 };
 
-const renderContent = <T extends React.ReactNode | ((args: CollapseRenderState) => React.ReactNode)>(
-  content: T,
+const renderContent = (
+  content: React.ReactNode | ((args: CollapseRenderState) => React.ReactNode),
   state: CollapseRenderState
-) => {
+): React.ReactNode => {
   return typeof content === 'function' ? content(state) : content;
 };
 

--- a/packages/react/src/color-picker/types.ts
+++ b/packages/react/src/color-picker/types.ts
@@ -17,7 +17,7 @@ export interface ColorChangeMeta {
 
 export interface ColorPickerProps
   extends BaseProps,
-    Omit<React.PropsWithoutRef<JSX.IntrinsicElements['div']>, 'onChange' | 'defaultValue'> {
+    Omit<React.ComponentPropsWithoutRef<'div'>, 'onChange' | 'defaultValue'> {
   value?: string;
   defaultValue?: string;
   onChange?: (color: string, meta: ColorChangeMeta) => void;

--- a/packages/react/src/copy-to-clipboard/types.ts
+++ b/packages/react/src/copy-to-clipboard/types.ts
@@ -3,7 +3,7 @@ import { BaseProps } from '../_utils/props';
 
 export interface CopyToClipboardProps
   extends BaseProps,
-    Omit<React.PropsWithoutRef<JSX.IntrinsicElements['span']>, 'onCopy'> {
+    Omit<React.ComponentPropsWithoutRef<'span'>, 'onCopy'> {
   text: string;
   onCopy?: (copied: boolean, text: string) => void;
   children?: React.ReactNode;

--- a/packages/react/src/descriptions/col.tsx
+++ b/packages/react/src/descriptions/col.tsx
@@ -15,6 +15,7 @@ const Col = (props: Props): React.ReactElement => {
   const { item, colon, type, bordered, prefixCls } = props;
 
   const { label, children, span = 1 } = item.props;
+  const resolvedSpan = typeof span === 'number' ? span : 1;
   switch (type) {
     case 'item': {
       const labelCls = classNames(`${prefixCls}__item-label`, {
@@ -26,14 +27,14 @@ const Col = (props: Props): React.ReactElement => {
             <th className={labelCls} colSpan={1}>
               {label}
             </th>
-            <td className={`${prefixCls}__item-content`} colSpan={span * 2 - 1}>
+            <td className={`${prefixCls}__item-content`} colSpan={resolvedSpan * 2 - 1}>
               {children}
             </td>
           </>
         );
       } else {
         return (
-          <td className={`${prefixCls}__item`} colSpan={span}>
+          <td className={`${prefixCls}__item`} colSpan={resolvedSpan}>
             <span className={labelCls}>{label}</span>
             <span className={`${prefixCls}__item-content`}>{children}</span>
           </td>
@@ -46,7 +47,7 @@ const Col = (props: Props): React.ReactElement => {
         `${prefixCls}__item-label`
       );
       return (
-        <th className={cls} colSpan={span}>
+        <th className={cls} colSpan={resolvedSpan}>
           {label}
         </th>
       );
@@ -54,7 +55,7 @@ const Col = (props: Props): React.ReactElement => {
     case 'content': {
       const cls = classNames({ [`${prefixCls}__item`]: !bordered }, `${prefixCls}__item-content`);
       return (
-        <td className={cls} colSpan={span}>
+        <td className={cls} colSpan={resolvedSpan}>
           {children}
         </td>
       );

--- a/packages/react/src/descriptions/descriptions.tsx
+++ b/packages/react/src/descriptions/descriptions.tsx
@@ -14,6 +14,8 @@ import {
   DescriptionsSpan,
 } from './types';
 
+const isProduction = (globalThis as { process?: { env?: { NODE_ENV?: string } } }).process?.env?.NODE_ENV === 'production';
+
 type NormalizedItem = DescriptionsItemType & {
   key: React.Key;
   content: React.ReactNode;
@@ -119,7 +121,7 @@ const Descriptions = (props: DescriptionsProps): React.ReactElement => {
 
   const normalizedItems = useMemo<NormalizedItem[]>(() => {
     if (items && items.length > 0) {
-      if (process.env.NODE_ENV !== 'production' && React.Children.count(children) > 0) {
+      if (!isProduction && React.Children.count(children) > 0) {
         warning(true, 'Descriptions `items` takes priority over `children`.');
       }
 

--- a/packages/react/src/descriptions/types.ts
+++ b/packages/react/src/descriptions/types.ts
@@ -17,7 +17,7 @@ export interface DescriptionsItemType extends BaseProps {
 
 export interface DescriptionsProps
   extends BaseProps,
-    Omit<React.ComponentProps<'div'>, 'title'> {
+    Omit<React.ComponentPropsWithoutRef<'div'>, 'title'> {
   title?: React.ReactNode;
   extra?: React.ReactNode;
   footer?: React.ReactNode;

--- a/packages/react/src/descriptions/types.ts
+++ b/packages/react/src/descriptions/types.ts
@@ -17,7 +17,7 @@ export interface DescriptionsItemType extends BaseProps {
 
 export interface DescriptionsProps
   extends BaseProps,
-    Omit<React.PropsWithRef<JSX.IntrinsicElements['div']>, 'title'> {
+    Omit<React.ComponentProps<'div'>, 'title'> {
   title?: React.ReactNode;
   extra?: React.ReactNode;
   footer?: React.ReactNode;

--- a/packages/react/src/divider/types.ts
+++ b/packages/react/src/divider/types.ts
@@ -7,7 +7,7 @@ export type DividerVariant = 'solid' | 'dashed' | 'dotted';
 
 export interface DividerProps
   extends BaseProps,
-    React.PropsWithoutRef<JSX.IntrinsicElements['div']> {
+    React.ComponentPropsWithoutRef<'div'> {
   orientation?: DividerOrientation;
   variant?: DividerVariant;
   titlePlacement?: DividerTitlePlacement;

--- a/packages/react/src/empty/types.ts
+++ b/packages/react/src/empty/types.ts
@@ -1,7 +1,7 @@
 import React, { CSSProperties, ReactNode } from 'react';
 import { BaseProps } from '../_utils/props';
 
-export interface EmptyProps extends BaseProps, React.PropsWithoutRef<JSX.IntrinsicElements['div']> {
+export interface EmptyProps extends BaseProps, React.ComponentPropsWithoutRef<'div'> {
   image?: string | ReactNode;
   imageStyle?: CSSProperties;
   description?: boolean | string | React.ReactNode;

--- a/packages/react/src/flex/types.ts
+++ b/packages/react/src/flex/types.ts
@@ -1,7 +1,7 @@
 import React from 'react';
 import { BaseProps, SizeType } from '../_utils/props';
 
-export interface FlexProps extends BaseProps, React.PropsWithRef<JSX.IntrinsicElements['div']> {
+export interface FlexProps extends BaseProps, React.ComponentProps<'div'> {
   vertical?: boolean;
   wrap?: React.CSSProperties['flexWrap'];
   justify?: React.CSSProperties['justifyContent'];

--- a/packages/react/src/flex/types.ts
+++ b/packages/react/src/flex/types.ts
@@ -1,7 +1,7 @@
 import React from 'react';
 import { BaseProps, SizeType } from '../_utils/props';
 
-export interface FlexProps extends BaseProps, React.ComponentProps<'div'> {
+export interface FlexProps extends BaseProps, React.ComponentPropsWithoutRef<'div'> {
   vertical?: boolean;
   wrap?: React.CSSProperties['flexWrap'];
   justify?: React.CSSProperties['justifyContent'];

--- a/packages/react/src/flip/types.ts
+++ b/packages/react/src/flip/types.ts
@@ -1,7 +1,7 @@
 import React from 'react';
 import { BaseProps, DirectionType } from '../_utils/props';
 
-export interface FlipProps extends BaseProps, React.PropsWithoutRef<JSX.IntrinsicElements['div']> {
+export interface FlipProps extends BaseProps, React.ComponentPropsWithoutRef<'div'> {
   /** a certain parent width and height to prevent the hover empty issue */
   width: string | number;
   height: string | number;
@@ -16,6 +16,6 @@ export interface FlipProps extends BaseProps, React.PropsWithoutRef<JSX.Intrinsi
 
 export interface FlipItemProps
   extends Omit<BaseProps, 'prefixCls'>,
-    React.PropsWithoutRef<JSX.IntrinsicElements['div']> {
+    React.ComponentPropsWithoutRef<'div'> {
   children?: React.ReactNode;
 }

--- a/packages/react/src/form/__tests__/form.test.tsx
+++ b/packages/react/src/form/__tests__/form.test.tsx
@@ -60,4 +60,16 @@ describe('<Form />', () => {
     fireEvent.click(screen.getByText('submit'));
     expect(screen.getByText('username required')).toBeInTheDocument();
   });
+
+  it('should forward ref to native form element', () => {
+    const ref = React.createRef<HTMLFormElement>();
+
+    render(
+      <Form ref={ref}>
+        <button type="submit">submit</button>
+      </Form>
+    );
+
+    expect(ref.current).toBeInstanceOf(HTMLFormElement);
+  });
 });

--- a/packages/react/src/form/form.tsx
+++ b/packages/react/src/form/form.tsx
@@ -7,7 +7,7 @@ import { getPrefixCls } from '../_utils/general';
 import { FormProps } from './types';
 import FormInstance from './form-instance';
 
-const Form = (props: FormProps): JSX.Element => {
+const Form = React.forwardRef<HTMLFormElement, FormProps>((props, ref): JSX.Element => {
   const {
     initialValues = {},
     labelCol = { span: 8, offset: 0 },
@@ -49,13 +49,13 @@ const Form = (props: FormProps): JSX.Element => {
   return (
     <FormInstanceContext.Provider value={formRef.current}>
       <FormOptionsContext.Provider value={{ labelCol, wrapperCol, validateTrigger, layout }}>
-        <form {...otherProps} className={cls} onSubmit={formOnSubmit} onReset={formOnReset}>
+        <form {...otherProps} ref={ref} className={cls} onSubmit={formOnSubmit} onReset={formOnReset}>
           {children}
         </form>
       </FormOptionsContext.Provider>
     </FormInstanceContext.Provider>
   );
-};
+});
 
 Form.displayName = 'Form';
 

--- a/packages/react/src/form/types.ts
+++ b/packages/react/src/form/types.ts
@@ -66,7 +66,7 @@ export interface FormOptionsProps {
 export interface FormProps
   extends BaseProps,
     Partial<FormOptionsProps>,
-    React.PropsWithRef<JSX.IntrinsicElements['form']> {
+    React.ComponentProps<'form'> {
   form?: FormInstance;
   initialValues?: FormValues;
   onFinish?: (values: FormValues) => void;

--- a/packages/react/src/form/types.ts
+++ b/packages/react/src/form/types.ts
@@ -66,7 +66,7 @@ export interface FormOptionsProps {
 export interface FormProps
   extends BaseProps,
     Partial<FormOptionsProps>,
-    React.ComponentProps<'form'> {
+    React.ComponentPropsWithoutRef<'form'> {
   form?: FormInstance;
   initialValues?: FormValues;
   onFinish?: (values: FormValues) => void;

--- a/packages/react/src/grid/types.ts
+++ b/packages/react/src/grid/types.ts
@@ -11,7 +11,7 @@ export type RowJustify =
   | 'space-between'
   | 'space-evenly';
 
-export interface RowProps extends BaseProps, React.ComponentProps<'div'> {
+export interface RowProps extends BaseProps, React.ComponentPropsWithoutRef<'div'> {
   gutter?: number | [number, number];
   gutterSide?: boolean;
   align?: RowAlign;
@@ -29,7 +29,7 @@ export type GridTrackValue = number | React.CSSProperties['gridTemplateColumns']
 export type GridItemSize = number | 'auto' | 'grow' | 'full';
 export type GridItemOffset = number | 'auto';
 
-export interface GridProps extends BaseProps, React.ComponentProps<'div'> {
+export interface GridProps extends BaseProps, React.ComponentPropsWithoutRef<'div'> {
   columns?: ResponsiveValue<GridTrackValue>;
   rows?: ResponsiveValue<React.CSSProperties['gridTemplateRows']>;
   spacing?: ResponsiveValue<SizeType | React.CSSProperties['gap']>;
@@ -51,7 +51,7 @@ export interface GridProps extends BaseProps, React.ComponentProps<'div'> {
   component?: React.ElementType;
 }
 
-export interface GridItemProps extends BaseProps, React.ComponentProps<'div'> {
+export interface GridItemProps extends BaseProps, React.ComponentPropsWithoutRef<'div'> {
   size?: ResponsiveValue<GridItemSize>;
   offset?: ResponsiveValue<GridItemOffset>;
   column?: ResponsiveValue<React.CSSProperties['gridColumn']>;
@@ -64,7 +64,7 @@ export interface GridItemProps extends BaseProps, React.ComponentProps<'div'> {
   component?: React.ElementType;
 }
 
-export interface ColProps extends BaseProps, React.ComponentProps<'div'> {
+export interface ColProps extends BaseProps, React.ComponentPropsWithoutRef<'div'> {
   span?: number;
   offset?: number;
   order?: number;

--- a/packages/react/src/grid/types.ts
+++ b/packages/react/src/grid/types.ts
@@ -11,7 +11,7 @@ export type RowJustify =
   | 'space-between'
   | 'space-evenly';
 
-export interface RowProps extends BaseProps, React.PropsWithRef<JSX.IntrinsicElements['div']> {
+export interface RowProps extends BaseProps, React.ComponentProps<'div'> {
   gutter?: number | [number, number];
   gutterSide?: boolean;
   align?: RowAlign;
@@ -29,7 +29,7 @@ export type GridTrackValue = number | React.CSSProperties['gridTemplateColumns']
 export type GridItemSize = number | 'auto' | 'grow' | 'full';
 export type GridItemOffset = number | 'auto';
 
-export interface GridProps extends BaseProps, React.PropsWithRef<JSX.IntrinsicElements['div']> {
+export interface GridProps extends BaseProps, React.ComponentProps<'div'> {
   columns?: ResponsiveValue<GridTrackValue>;
   rows?: ResponsiveValue<React.CSSProperties['gridTemplateRows']>;
   spacing?: ResponsiveValue<SizeType | React.CSSProperties['gap']>;
@@ -51,7 +51,7 @@ export interface GridProps extends BaseProps, React.PropsWithRef<JSX.IntrinsicEl
   component?: React.ElementType;
 }
 
-export interface GridItemProps extends BaseProps, React.PropsWithRef<JSX.IntrinsicElements['div']> {
+export interface GridItemProps extends BaseProps, React.ComponentProps<'div'> {
   size?: ResponsiveValue<GridItemSize>;
   offset?: ResponsiveValue<GridItemOffset>;
   column?: ResponsiveValue<React.CSSProperties['gridColumn']>;
@@ -64,7 +64,7 @@ export interface GridItemProps extends BaseProps, React.PropsWithRef<JSX.Intrins
   component?: React.ElementType;
 }
 
-export interface ColProps extends BaseProps, React.PropsWithRef<JSX.IntrinsicElements['div']> {
+export interface ColProps extends BaseProps, React.ComponentProps<'div'> {
   span?: number;
   offset?: number;
   order?: number;

--- a/packages/react/src/image/types.ts
+++ b/packages/react/src/image/types.ts
@@ -3,7 +3,7 @@ import { BaseProps } from '../_utils/props';
 
 export interface ImageProps
   extends BaseProps,
-    Omit<React.PropsWithoutRef<JSX.IntrinsicElements['img']>, 'placeholder'> {
+    Omit<React.ComponentPropsWithoutRef<'img'>, 'placeholder'> {
   src?: string;
   placeholder?: React.ReactNode;
   alt?: string;

--- a/packages/react/src/input/types.ts
+++ b/packages/react/src/input/types.ts
@@ -3,7 +3,7 @@ import { BaseProps, SizeType } from '../_utils/props';
 
 export interface InputProps
   extends BaseProps,
-    Omit<React.ComponentProps<'input'>, 'size' | 'prefix'> {
+    Omit<React.ComponentPropsWithoutRef<'input'>, 'size' | 'prefix'> {
   clearable?: boolean;
   prefix?: ReactNode;
   suffix?: ReactNode;

--- a/packages/react/src/input/types.ts
+++ b/packages/react/src/input/types.ts
@@ -3,7 +3,7 @@ import { BaseProps, SizeType } from '../_utils/props';
 
 export interface InputProps
   extends BaseProps,
-    Omit<React.PropsWithRef<JSX.IntrinsicElements['input']>, 'size' | 'prefix'> {
+    Omit<React.ComponentProps<'input'>, 'size' | 'prefix'> {
   clearable?: boolean;
   prefix?: ReactNode;
   suffix?: ReactNode;
@@ -19,7 +19,7 @@ export interface InputProps
 
 export interface InputGroupProps
   extends BaseProps,
-    React.PropsWithoutRef<JSX.IntrinsicElements['div']> {
+    React.ComponentPropsWithoutRef<'div'> {
   size?: SizeType;
   disabled?: boolean;
   children: React.ReactNode;
@@ -27,7 +27,7 @@ export interface InputGroupProps
 
 export interface InputGroupAddonProps
   extends BaseProps,
-    React.PropsWithoutRef<JSX.IntrinsicElements['div']> {
+    React.ComponentPropsWithoutRef<'div'> {
   noBorder?: boolean;
   disabled?: boolean;
   size?: SizeType;

--- a/packages/react/src/keyboard/types.ts
+++ b/packages/react/src/keyboard/types.ts
@@ -1,6 +1,6 @@
 import React from 'react';
 import { BaseProps } from '../_utils/props';
 
-export interface KeyboardProps extends BaseProps, React.ComponentProps<'kbd'> {
+export interface KeyboardProps extends BaseProps, React.ComponentPropsWithoutRef<'kbd'> {
   children?: React.ReactNode;
 }

--- a/packages/react/src/keyboard/types.ts
+++ b/packages/react/src/keyboard/types.ts
@@ -1,6 +1,6 @@
 import React from 'react';
 import { BaseProps } from '../_utils/props';
 
-export interface KeyboardProps extends BaseProps, React.PropsWithRef<JSX.IntrinsicElements['kbd']> {
+export interface KeyboardProps extends BaseProps, React.ComponentProps<'kbd'> {
   children?: React.ReactNode;
 }

--- a/packages/react/src/layout/types.ts
+++ b/packages/react/src/layout/types.ts
@@ -1,11 +1,11 @@
 import React from 'react';
 import { BaseProps } from '../_utils/props';
 
-export interface LayoutProps extends BaseProps, React.ComponentProps<'div'> {}
+export interface LayoutProps extends BaseProps, React.ComponentPropsWithoutRef<'div'> {}
 
 export type SidebarTheme = 'light' | 'dark';
 
-export interface SidebarProps extends BaseProps, React.ComponentProps<'div'> {
+export interface SidebarProps extends BaseProps, React.ComponentPropsWithoutRef<'div'> {
   collapsible?: boolean;
   collapsed?: boolean;
   defaultCollapsed?: boolean;

--- a/packages/react/src/layout/types.ts
+++ b/packages/react/src/layout/types.ts
@@ -1,11 +1,11 @@
 import React from 'react';
 import { BaseProps } from '../_utils/props';
 
-export interface LayoutProps extends BaseProps, React.PropsWithRef<JSX.IntrinsicElements['div']> {}
+export interface LayoutProps extends BaseProps, React.ComponentProps<'div'> {}
 
 export type SidebarTheme = 'light' | 'dark';
 
-export interface SidebarProps extends BaseProps, React.PropsWithRef<JSX.IntrinsicElements['div']> {
+export interface SidebarProps extends BaseProps, React.ComponentProps<'div'> {
   collapsible?: boolean;
   collapsed?: boolean;
   defaultCollapsed?: boolean;

--- a/packages/react/src/link/__tests__/link.test.tsx
+++ b/packages/react/src/link/__tests__/link.test.tsx
@@ -24,4 +24,18 @@ describe('<Link />', () => {
     const { container } = render(<Link disabled>Link</Link>);
     expect(container.firstChild).toHaveClass('ty-link_disabled');
   });
+
+  it('should forward ref to anchor element', () => {
+    const ref = React.createRef<HTMLAnchorElement | HTMLSpanElement>();
+    render(<Link ref={ref} href="#">Link</Link>);
+
+    expect(ref.current).toBeInstanceOf(HTMLAnchorElement);
+  });
+
+  it('should forward ref to disabled fallback element', () => {
+    const ref = React.createRef<HTMLAnchorElement | HTMLSpanElement>();
+    render(<Link ref={ref} disabled>Link</Link>);
+
+    expect(ref.current).toBeInstanceOf(HTMLSpanElement);
+  });
 });

--- a/packages/react/src/link/link.tsx
+++ b/packages/react/src/link/link.tsx
@@ -4,43 +4,47 @@ import { ConfigContext } from '../config-provider/config-context';
 import { getPrefixCls } from '../_utils/general';
 import { LinkProps } from './types';
 
-const Link = React.memo((props: LinkProps): React.ReactElement => {
-  const {
-    disabled = false,
-    external = true,
-    underline = true,
-    className,
-    style,
-    children,
-    target,
-    prefixCls: customisedCls,
-    ...otherProps
-  } = props;
-  const configContext = useContext(ConfigContext);
-  const prefixCls = getPrefixCls('link', configContext.prefixCls, customisedCls);
-  const cls = classNames(prefixCls, className, {
-    [`${prefixCls}_disabled`]: disabled,
-    [`${prefixCls}_no-underline`]: !underline,
-  });
+const Link = React.memo(
+  React.forwardRef<HTMLAnchorElement | HTMLSpanElement, LinkProps>((props, ref): React.ReactElement => {
+    const {
+      disabled = false,
+      external = true,
+      underline = true,
+      className,
+      style,
+      children,
+      target,
+      prefixCls: customisedCls,
+      ...otherProps
+    } = props;
+    const configContext = useContext(ConfigContext);
+    const prefixCls = getPrefixCls('link', configContext.prefixCls, customisedCls);
+    const cls = classNames(prefixCls, className, {
+      [`${prefixCls}_disabled`]: disabled,
+      [`${prefixCls}_no-underline`]: !underline,
+    });
 
-  if (disabled) {
+    if (disabled) {
+      return (
+        <span ref={ref as React.Ref<HTMLSpanElement>} className={cls} style={style} role="link" aria-disabled="true">
+          <span>{children}</span>
+        </span>
+      );
+    }
+
     return (
-      <span className={cls} style={style} role="link" aria-disabled="true">
+      <a
+        {...otherProps}
+        ref={ref as React.Ref<HTMLAnchorElement>}
+        target={target ? target : external ? '_blank' : '_self'}
+        className={cls}
+        style={style}
+        role="link">
         <span>{children}</span>
-      </span>
+      </a>
     );
-  }
-  return (
-    <a
-      {...otherProps}
-      target={target ? target : external ? '_blank' : '_self'}
-      className={cls}
-      style={style}
-      role="link">
-      <span>{children}</span>
-    </a>
-  );
-});
+  })
+);
 
 Link.displayName = 'Link';
 

--- a/packages/react/src/link/types.ts
+++ b/packages/react/src/link/types.ts
@@ -1,7 +1,7 @@
 import React from 'react';
 import { BaseProps } from '../_utils/props';
 
-export interface LinkProps extends BaseProps, React.ComponentProps<'a'> {
+export interface LinkProps extends BaseProps, React.ComponentPropsWithoutRef<'a'> {
   external?: boolean;
   disabled?: boolean;
   underline?: boolean;

--- a/packages/react/src/link/types.ts
+++ b/packages/react/src/link/types.ts
@@ -1,7 +1,7 @@
 import React from 'react';
 import { BaseProps } from '../_utils/props';
 
-export interface LinkProps extends BaseProps, React.PropsWithRef<JSX.IntrinsicElements['a']> {
+export interface LinkProps extends BaseProps, React.ComponentProps<'a'> {
   external?: boolean;
   disabled?: boolean;
   underline?: boolean;

--- a/packages/react/src/list/types.ts
+++ b/packages/react/src/list/types.ts
@@ -4,7 +4,7 @@ import { PaginationProps } from '../pagination/types';
 
 export interface ListProps<T = any>
   extends BaseProps,
-    Omit<React.PropsWithoutRef<JSX.IntrinsicElements['div']>, 'children'> {
+    Omit<React.ComponentPropsWithoutRef<'div'>, 'children'> {
   dataSource?: T[];
   renderItem?: (item: T, index: number) => React.ReactNode;
   header?: React.ReactNode;
@@ -36,7 +36,7 @@ export interface ListPaginationProps extends Pick<PaginationProps, 'size' | 'ali
 
 export interface ListItemProps
   extends BaseProps,
-    React.PropsWithoutRef<JSX.IntrinsicElements['li']> {
+    React.ComponentPropsWithoutRef<'li'> {
   extra?: React.ReactNode;
   actions?: React.ReactNode[];
   children?: React.ReactNode;
@@ -44,7 +44,7 @@ export interface ListItemProps
 
 export interface ListItemMetaProps
   extends BaseProps,
-    Omit<React.PropsWithoutRef<JSX.IntrinsicElements['div']>, 'title'> {
+    Omit<React.ComponentPropsWithoutRef<'div'>, 'title'> {
   avatar?: React.ReactNode;
   title?: React.ReactNode;
   description?: React.ReactNode;

--- a/packages/react/src/loader/types.ts
+++ b/packages/react/src/loader/types.ts
@@ -3,7 +3,7 @@ import { BaseProps, SizeType } from '../_utils/props';
 
 export interface LoaderProps
   extends BaseProps,
-    React.PropsWithoutRef<JSX.IntrinsicElements['div']> {
+    React.ComponentPropsWithoutRef<'div'> {
   /** customise the spinning indicator */
   indicator?: ReactNode;
 

--- a/packages/react/src/loading-bar/types.ts
+++ b/packages/react/src/loading-bar/types.ts
@@ -3,7 +3,7 @@ import { BaseProps } from '../_utils/props';
 
 export interface LoadingBarProps
   extends BaseProps,
-    React.PropsWithoutRef<JSX.IntrinsicElements['div']> {
+    React.ComponentPropsWithoutRef<'div'> {
   didMount?: () => void;
   children?: React.ReactNode;
 }

--- a/packages/react/src/marquee/types.ts
+++ b/packages/react/src/marquee/types.ts
@@ -3,7 +3,7 @@ import { BaseProps } from '../_utils/props';
 
 export interface MarqueeProps
   extends BaseProps,
-    React.PropsWithoutRef<JSX.IntrinsicElements['div']> {
+    React.ComponentPropsWithoutRef<'div'> {
   /** Scroll direction */
   direction?: 'left' | 'right';
 

--- a/packages/react/src/menu/types.ts
+++ b/packages/react/src/menu/types.ts
@@ -15,7 +15,7 @@ export interface MenuSelectInfo {
 
 export interface MenuProps
   extends BaseProps,
-    Omit<React.PropsWithoutRef<JSX.IntrinsicElements['ul']>, 'onSelect'> {
+    Omit<React.ComponentPropsWithoutRef<'ul'>, 'onSelect'> {
   defaultIndex?: string;
   selectedKeys?: string[];
   defaultSelectedKeys?: string[];
@@ -55,7 +55,7 @@ export interface MenuProps
 
 export interface MenuItemProps
   extends BaseProps,
-    React.PropsWithoutRef<JSX.IntrinsicElements['li']> {
+    React.ComponentPropsWithoutRef<'li'> {
   index?: string;
   disabled?: boolean;
   danger?: boolean;
@@ -66,14 +66,14 @@ export interface MenuItemProps
 
 export interface MenuItemGroupProps
   extends BaseProps,
-    Omit<React.PropsWithoutRef<JSX.IntrinsicElements['li']>, 'title'> {
+    Omit<React.ComponentPropsWithoutRef<'li'>, 'title'> {
   index?: string;
   title?: ReactNode;
 }
 
 export interface SubMenuProps
   extends BaseProps,
-    Omit<React.PropsWithoutRef<JSX.IntrinsicElements['li']>, 'title'> {
+    Omit<React.ComponentPropsWithoutRef<'li'>, 'title'> {
   title: ReactNode;
   index?: string;
   disabled?: boolean;

--- a/packages/react/src/native-select/types.ts
+++ b/packages/react/src/native-select/types.ts
@@ -1,13 +1,13 @@
 import React from 'react';
 import { BaseProps, SizeType } from '../_utils/props';
 
-export type NativeSelectGroupProps = React.PropsWithRef<JSX.IntrinsicElements['optgroup']>;
+export type NativeSelectGroupProps = React.ComponentProps<'optgroup'>;
 
-export type NativeSelectOptionProps = React.PropsWithRef<JSX.IntrinsicElements['option']>;
+export type NativeSelectOptionProps = React.ComponentProps<'option'>;
 
 export interface NativeSelectProps
   extends BaseProps,
-    Omit<React.PropsWithRef<JSX.IntrinsicElements['select']>, 'size'> {
+    Omit<React.ComponentProps<'select'>, 'size'> {
   size?: SizeType;
   children:
     | React.ReactElement<NativeSelectGroupProps | NativeSelectOptionProps>

--- a/packages/react/src/native-select/types.ts
+++ b/packages/react/src/native-select/types.ts
@@ -1,13 +1,13 @@
 import React from 'react';
 import { BaseProps, SizeType } from '../_utils/props';
 
-export type NativeSelectGroupProps = React.ComponentProps<'optgroup'>;
+export type NativeSelectGroupProps = React.ComponentPropsWithoutRef<'optgroup'>;
 
-export type NativeSelectOptionProps = React.ComponentProps<'option'>;
+export type NativeSelectOptionProps = React.ComponentPropsWithoutRef<'option'>;
 
 export interface NativeSelectProps
   extends BaseProps,
-    Omit<React.ComponentProps<'select'>, 'size'> {
+    Omit<React.ComponentPropsWithoutRef<'select'>, 'size'> {
   size?: SizeType;
   children:
     | React.ReactElement<NativeSelectGroupProps | NativeSelectOptionProps>

--- a/packages/react/src/notification/types.ts
+++ b/packages/react/src/notification/types.ts
@@ -5,7 +5,7 @@ export type NotificationType = 'success' | 'error' | 'warning' | 'info' | undefi
 
 export interface NotificationProps
   extends BaseProps,
-    Omit<React.PropsWithoutRef<JSX.IntrinsicElements['div']>, 'title'> {
+    Omit<React.ComponentPropsWithoutRef<'div'>, 'title'> {
   type: NotificationType;
   title?: ReactNode;
   description?: ReactNode;

--- a/packages/react/src/pagination/types.ts
+++ b/packages/react/src/pagination/types.ts
@@ -6,7 +6,7 @@ export type PaginationSize = 'sm' | 'md';
 
 export interface PaginationProps
   extends BaseProps,
-    Omit<React.PropsWithoutRef<JSX.IntrinsicElements['ul']>, 'onChange'> {
+    Omit<React.ComponentPropsWithoutRef<'ul'>, 'onChange'> {
   current?: number;
   total?: number;
   defaultCurrent?: number;

--- a/packages/react/src/popup/types.ts
+++ b/packages/react/src/popup/types.ts
@@ -17,7 +17,7 @@ export type Placement =
   | 'right'
   | 'right-end';
 
-export interface PopupProps extends BaseProps, Omit<React.PropsWithoutRef<JSX.IntrinsicElements['div']>, 'children' | 'content'> {
+export interface PopupProps extends BaseProps, Omit<React.ComponentPropsWithoutRef<'div'>, 'children' | 'content'> {
   disabled?: boolean;
   content?: React.ReactNode;
   placement?: Placement;

--- a/packages/react/src/progress/types.ts
+++ b/packages/react/src/progress/types.ts
@@ -7,7 +7,7 @@ export const strokePresetColors = ['primary', 'blue', 'green', 'yellow', 'red'];
 
 export type BarBackgroundType = 'impulse' | 'striped';
 
-export interface BarProps extends BaseProps, React.PropsWithoutRef<JSX.IntrinsicElements['div']> {
+export interface BarProps extends BaseProps, React.ComponentPropsWithoutRef<'div'> {
   percent?: number;
   /** Customise label style for both outer and inner label */
   format?: (percent: number) => React.ReactNode;
@@ -24,7 +24,7 @@ export interface BarProps extends BaseProps, React.PropsWithoutRef<JSX.Intrinsic
 
 export interface CircleProps
   extends BaseProps,
-    React.PropsWithoutRef<JSX.IntrinsicElements['div']> {
+    React.ComponentPropsWithoutRef<'div'> {
   percent?: number;
   /** Customise label style for both outer and inner label */
   format?: (percent: number) => React.ReactNode;

--- a/packages/react/src/radio/radio-group.tsx
+++ b/packages/react/src/radio/radio-group.tsx
@@ -5,52 +5,50 @@ import { getPrefixCls } from '../_utils/general';
 import { RadioGroupContext } from './radio-group-context';
 import { RadioGroupProps } from './types';
 
-const RadioGroup = React.forwardRef<HTMLDivElement, RadioGroupProps>(
-  (props: RadioGroupProps, ref): JSX.Element => {
-    const {
-      defaultValue = '',
-      disabled = false,
-      name,
-      onChange,
-      className,
-      children,
-      prefixCls: customisedCls,
-      ...otherProps
-    } = props;
-    const configContext = useContext(ConfigContext);
-    const prefixCls = getPrefixCls('radio-group', configContext.prefixCls, customisedCls);
-    const cls = classNames(prefixCls, className);
-    const [value, setValue] = useState<number | string>(
-      'value' in props ? (props.value as number | string) : defaultValue
-    );
+const RadioGroup = (props: RadioGroupProps): JSX.Element => {
+  const {
+    defaultValue = '',
+    disabled = false,
+    name,
+    onChange,
+    className,
+    children,
+    prefixCls: customisedCls,
+    ...otherProps
+  } = props;
+  const configContext = useContext(ConfigContext);
+  const prefixCls = getPrefixCls('radio-group', configContext.prefixCls, customisedCls);
+  const cls = classNames(prefixCls, className);
+  const [value, setValue] = useState<number | string>(
+    'value' in props ? (props.value as number | string) : defaultValue
+  );
 
-    const radioOnChange = (e: React.ChangeEvent<HTMLInputElement>): void => {
-      if (!disabled) {
-        const val = e.currentTarget.value;
-        !('value' in props) && setValue(val);
-        onChange && onChange(val);
-      }
-    };
+  const radioOnChange = (e: React.ChangeEvent<HTMLInputElement>): void => {
+    if (!disabled) {
+      const val = e.currentTarget.value;
+      !('value' in props) && setValue(val);
+      onChange && onChange(val);
+    }
+  };
 
-    useEffect(() => {
-      'value' in props && setValue(props.value as number | string);
-    }, [props]);
+  useEffect(() => {
+    'value' in props && setValue(props.value as number | string);
+  }, [props]);
 
-    return (
-      <RadioGroupContext.Provider
-        value={{
-          name,
-          disabled,
-          value,
-          onChange: radioOnChange,
-        }}>
-        <div {...otherProps} ref={ref} role="radiogroup" className={cls}>
-          {children}
-        </div>
-      </RadioGroupContext.Provider>
-    );
-  }
-);
+  return (
+    <RadioGroupContext.Provider
+      value={{
+        name,
+        disabled,
+        value,
+        onChange: radioOnChange,
+      }}>
+      <div {...otherProps} role="radiogroup" className={cls}>
+        {children}
+      </div>
+    </RadioGroupContext.Provider>
+  );
+};
 
 RadioGroup.displayName = 'RadioGroup';
 

--- a/packages/react/src/radio/types.ts
+++ b/packages/react/src/radio/types.ts
@@ -3,7 +3,7 @@ import { BaseProps } from '../_utils/props';
 
 export interface RadioProps
   extends BaseProps,
-    Omit<React.ComponentProps<'label'>, 'onChange'> {
+    Omit<React.ComponentPropsWithoutRef<'label'>, 'onChange'> {
   radioRef?: RefObject<HTMLInputElement>;
   value?: string | number;
   name?: string;
@@ -15,7 +15,7 @@ export interface RadioProps
 
 export interface RadioGroupProps
   extends BaseProps,
-    Omit<React.ComponentProps<'div'>, 'onChange'> {
+    Omit<React.ComponentPropsWithoutRef<'div'>, 'onChange'> {
   name?: string;
   defaultValue?: number | string;
   value?: number | string;

--- a/packages/react/src/radio/types.ts
+++ b/packages/react/src/radio/types.ts
@@ -3,7 +3,7 @@ import { BaseProps } from '../_utils/props';
 
 export interface RadioProps
   extends BaseProps,
-    Omit<React.PropsWithRef<JSX.IntrinsicElements['label']>, 'onChange'> {
+    Omit<React.ComponentProps<'label'>, 'onChange'> {
   radioRef?: RefObject<HTMLInputElement>;
   value?: string | number;
   name?: string;
@@ -15,7 +15,7 @@ export interface RadioProps
 
 export interface RadioGroupProps
   extends BaseProps,
-    Omit<React.PropsWithRef<JSX.IntrinsicElements['div']>, 'onChange'> {
+    Omit<React.ComponentProps<'div'>, 'onChange'> {
   name?: string;
   defaultValue?: number | string;
   value?: number | string;

--- a/packages/react/src/rate/types.ts
+++ b/packages/react/src/rate/types.ts
@@ -3,7 +3,7 @@ import { ReactNode } from 'react';
 import { BaseProps } from '../_utils/props';
 
 export interface RateProps extends BaseProps,
-  Omit<React.PropsWithRef<JSX.IntrinsicElements['ul']>, 'onChange'> {
+  Omit<React.ComponentProps<'ul'>, 'onChange'> {
   color?: string;
   clearable?: boolean;
   half?: boolean;

--- a/packages/react/src/rate/types.ts
+++ b/packages/react/src/rate/types.ts
@@ -3,7 +3,7 @@ import { ReactNode } from 'react';
 import { BaseProps } from '../_utils/props';
 
 export interface RateProps extends BaseProps,
-  Omit<React.ComponentProps<'ul'>, 'onChange'> {
+  Omit<React.ComponentPropsWithoutRef<'ul'>, 'onChange'> {
   color?: string;
   clearable?: boolean;
   half?: boolean;

--- a/packages/react/src/result/types.ts
+++ b/packages/react/src/result/types.ts
@@ -5,7 +5,7 @@ export type ResultStatus = 'success' | 'error' | 'info' | 'warning' | 'loading';
 
 export interface ResultProps
   extends BaseProps,
-    Omit<React.PropsWithRef<JSX.IntrinsicElements['div']>, 'title'> {
+    Omit<React.ComponentProps<'div'>, 'title'> {
   title?: ReactNode;
   subtitle?: ReactNode;
   status?: ResultStatus;

--- a/packages/react/src/result/types.ts
+++ b/packages/react/src/result/types.ts
@@ -5,7 +5,7 @@ export type ResultStatus = 'success' | 'error' | 'info' | 'warning' | 'loading';
 
 export interface ResultProps
   extends BaseProps,
-    Omit<React.ComponentProps<'div'>, 'title'> {
+    Omit<React.ComponentPropsWithoutRef<'div'>, 'title'> {
   title?: ReactNode;
   subtitle?: ReactNode;
   status?: ResultStatus;

--- a/packages/react/src/scroll-indicator/types.ts
+++ b/packages/react/src/scroll-indicator/types.ts
@@ -4,7 +4,7 @@ import { Target } from '../_utils/dom';
 
 export interface ScrollIndicatorProps
   extends BaseProps,
-    React.PropsWithoutRef<JSX.IntrinsicElements['div']> {
+    React.ComponentPropsWithoutRef<'div'> {
   fixed?: boolean;
   target?: () => Target;
 }

--- a/packages/react/src/scroll-number/types.ts
+++ b/packages/react/src/scroll-number/types.ts
@@ -3,7 +3,7 @@ import { BaseProps } from '../_utils/props';
 
 export interface ScrollNumberProps
   extends BaseProps,
-    Omit<React.PropsWithoutRef<JSX.IntrinsicElements['div']>, 'title' | 'prefix'> {
+    Omit<React.ComponentPropsWithoutRef<'div'>, 'title' | 'prefix'> {
   /** The numeric value to display */
   value?: number | string;
   /** Title displayed above the value */

--- a/packages/react/src/segmented/types.ts
+++ b/packages/react/src/segmented/types.ts
@@ -15,7 +15,7 @@ export type SegmentedValue = string | number;
 export interface SegmentedProps
   extends BaseProps,
     Omit<
-      React.PropsWithoutRef<JSX.IntrinsicElements['div']>,
+      React.ComponentPropsWithoutRef<'div'>,
       'children' | 'defaultValue' | 'onChange'
     > {
   options: SegmentedOption[];

--- a/packages/react/src/select/types.ts
+++ b/packages/react/src/select/types.ts
@@ -3,14 +3,14 @@ import { BaseProps, SizeType } from '../_utils/props';
 
 export interface SelectOptGroupProps
   extends BaseProps,
-    React.PropsWithoutRef<JSX.IntrinsicElements['li']> {
+    React.ComponentPropsWithoutRef<'li'> {
   label?: string;
   children?: React.ReactNode;
 }
 
 export interface SelectOptionsProps
   extends BaseProps,
-    React.PropsWithoutRef<JSX.IntrinsicElements['li']> {
+    React.ComponentPropsWithoutRef<'li'> {
   value: string;
   label?: React.ReactNode;
   disabled?: boolean;
@@ -28,7 +28,7 @@ export type SelectValue = string | string[];
 export interface SelectProps
   extends BaseProps,
     Omit<
-      React.PropsWithoutRef<JSX.IntrinsicElements['div']>,
+      React.ComponentPropsWithoutRef<'div'>,
       'onSelect' | 'onChange' | 'defaultValue'
     > {
   value?: SelectValue;

--- a/packages/react/src/skeleton/types.ts
+++ b/packages/react/src/skeleton/types.ts
@@ -1,7 +1,7 @@
 import React from 'react';
 import { BaseProps } from '../_utils/props';
 
-export interface SkeletonProps extends BaseProps, React.ComponentProps<'div'> {
+export interface SkeletonProps extends BaseProps, React.ComponentPropsWithoutRef<'div'> {
   active?: boolean;
   rounded?: boolean;
   children?: React.ReactNode;

--- a/packages/react/src/skeleton/types.ts
+++ b/packages/react/src/skeleton/types.ts
@@ -1,7 +1,7 @@
 import React from 'react';
 import { BaseProps } from '../_utils/props';
 
-export interface SkeletonProps extends BaseProps, React.PropsWithRef<JSX.IntrinsicElements['div']> {
+export interface SkeletonProps extends BaseProps, React.ComponentProps<'div'> {
   active?: boolean;
   rounded?: boolean;
   children?: React.ReactNode;

--- a/packages/react/src/slider/types.ts
+++ b/packages/react/src/slider/types.ts
@@ -14,7 +14,7 @@ export type SliderMarks = {
 
 export interface SliderProps
   extends BaseProps,
-    Omit<React.PropsWithRef<JSX.IntrinsicElements['div']>, 'onChange' | 'defaultValue'> {
+    Omit<React.ComponentProps<'div'>, 'onChange' | 'defaultValue'> {
   value?: SliderValue;
   defaultValue?: SliderValue;
   min?: number;

--- a/packages/react/src/slider/types.ts
+++ b/packages/react/src/slider/types.ts
@@ -14,7 +14,7 @@ export type SliderMarks = {
 
 export interface SliderProps
   extends BaseProps,
-    Omit<React.ComponentProps<'div'>, 'onChange' | 'defaultValue'> {
+    Omit<React.ComponentPropsWithoutRef<'div'>, 'onChange' | 'defaultValue'> {
   value?: SliderValue;
   defaultValue?: SliderValue;
   min?: number;

--- a/packages/react/src/space/types.ts
+++ b/packages/react/src/space/types.ts
@@ -4,7 +4,7 @@ import { BaseProps, DirectionType, SizeType } from '../_utils/props';
 export type SpaceAlign = 'start' | 'end' | 'center' | 'baseline';
 export type SpaceSize = SizeType | number;
 
-export interface SpaceProps extends BaseProps, React.ComponentProps<'div'> {
+export interface SpaceProps extends BaseProps, React.ComponentPropsWithoutRef<'div'> {
   align?: SpaceAlign;
   direction?: DirectionType;
   size?: SpaceSize;

--- a/packages/react/src/space/types.ts
+++ b/packages/react/src/space/types.ts
@@ -4,7 +4,7 @@ import { BaseProps, DirectionType, SizeType } from '../_utils/props';
 export type SpaceAlign = 'start' | 'end' | 'center' | 'baseline';
 export type SpaceSize = SizeType | number;
 
-export interface SpaceProps extends BaseProps, React.PropsWithRef<JSX.IntrinsicElements['div']> {
+export interface SpaceProps extends BaseProps, React.ComponentProps<'div'> {
   align?: SpaceAlign;
   direction?: DirectionType;
   size?: SpaceSize;

--- a/packages/react/src/speed-dial/types.ts
+++ b/packages/react/src/speed-dial/types.ts
@@ -6,7 +6,7 @@ export type SpeedDialTrigger = 'hover' | 'click';
 
 export interface SpeedDialProps
   extends BaseProps,
-    Omit<React.PropsWithoutRef<JSX.IntrinsicElements['div']>, 'children'> {
+    Omit<React.ComponentPropsWithoutRef<'div'>, 'children'> {
   icon?: React.ReactNode;
   openIcon?: React.ReactNode;
   direction?: SpeedDialDirection;
@@ -20,7 +20,7 @@ export interface SpeedDialProps
 
 export interface SpeedDialActionProps
   extends BaseProps,
-    Omit<React.PropsWithoutRef<JSX.IntrinsicElements['button']>, 'children'> {
+    Omit<React.ComponentPropsWithoutRef<'button'>, 'children'> {
   icon: React.ReactNode;
   tooltip?: string;
   tooltipPlacement?: 'left' | 'right' | 'top' | 'bottom';

--- a/packages/react/src/split/resizer.tsx
+++ b/packages/react/src/split/resizer.tsx
@@ -7,7 +7,7 @@ import { SplitSeparatorRenderProps } from './types';
 
 export interface ResizerProps
   extends BaseProps,
-    React.PropsWithoutRef<JSX.IntrinsicElements['div']> {
+    React.ComponentPropsWithoutRef<'div'> {
   visualSize?: number;
   hitAreaSize: number;
   orientation: DirectionType;

--- a/packages/react/src/split/types.ts
+++ b/packages/react/src/split/types.ts
@@ -18,7 +18,7 @@ export type SplitSeparatorRenderProps = {
 
 export interface SplitPaneProps
   extends BaseProps,
-    Omit<React.PropsWithoutRef<JSX.IntrinsicElements['div']>, 'children'> {
+    Omit<React.ComponentPropsWithoutRef<'div'>, 'children'> {
   /** Minimum pane size */
   min?: SplitSize;
 
@@ -30,7 +30,7 @@ export interface SplitPaneProps
 
 export interface SplitProps
   extends BaseProps,
-    Omit<React.PropsWithoutRef<JSX.IntrinsicElements['div']>, 'children'> {
+    Omit<React.ComponentPropsWithoutRef<'div'>, 'children'> {
   /** Pane arrangement: horizontal => left/right, vertical => top/bottom */
   orientation?: SplitOrientation;
 

--- a/packages/react/src/statistic/types.ts
+++ b/packages/react/src/statistic/types.ts
@@ -49,7 +49,7 @@ export interface StatisticStatus {
 
 export interface StatisticProps
   extends BaseProps,
-    Omit<React.PropsWithoutRef<JSX.IntrinsicElements['div']>, 'title' | 'prefix'> {
+    Omit<React.ComponentPropsWithoutRef<'div'>, 'title' | 'prefix'> {
   title?: React.ReactNode;
   description?: React.ReactNode;
   tooltip?: React.ReactNode;

--- a/packages/react/src/steps/types.ts
+++ b/packages/react/src/steps/types.ts
@@ -5,7 +5,7 @@ export type StepsStatus = 'wait' | 'process' | 'finish' | 'error';
 
 export interface StepsProps
   extends BaseProps,
-    Omit<React.ComponentProps<'div'>, 'onChange'> {
+    Omit<React.ComponentPropsWithoutRef<'div'>, 'onChange'> {
   current?: number;
   defaultCurrent?: number;
   direction?: DirectionType;
@@ -16,7 +16,7 @@ export interface StepsProps
 
 export interface StepsItemProps
   extends BaseProps,
-    Omit<React.ComponentProps<'div'>, 'title'> {
+    Omit<React.ComponentPropsWithoutRef<'div'>, 'title'> {
   stepIndex?: number;
   icon?: ReactNode;
   title?: ReactNode;

--- a/packages/react/src/steps/types.ts
+++ b/packages/react/src/steps/types.ts
@@ -5,7 +5,7 @@ export type StepsStatus = 'wait' | 'process' | 'finish' | 'error';
 
 export interface StepsProps
   extends BaseProps,
-    Omit<React.PropsWithRef<JSX.IntrinsicElements['div']>, 'onChange'> {
+    Omit<React.ComponentProps<'div'>, 'onChange'> {
   current?: number;
   defaultCurrent?: number;
   direction?: DirectionType;
@@ -16,7 +16,7 @@ export interface StepsProps
 
 export interface StepsItemProps
   extends BaseProps,
-    Omit<React.PropsWithRef<JSX.IntrinsicElements['div']>, 'title'> {
+    Omit<React.ComponentProps<'div'>, 'title'> {
   stepIndex?: number;
   icon?: ReactNode;
   title?: ReactNode;

--- a/packages/react/src/sticky/types.ts
+++ b/packages/react/src/sticky/types.ts
@@ -4,7 +4,7 @@ import { Target } from '../_utils/dom';
 
 export interface StickyProps
   extends BaseProps,
-    Omit<React.PropsWithoutRef<JSX.IntrinsicElements['div']>, 'onChange'> {
+    Omit<React.ComponentPropsWithoutRef<'div'>, 'onChange'> {
   offsetTop?: number;
   offsetBottom?: number;
   container?: () => Target;

--- a/packages/react/src/strength-indicator/types.ts
+++ b/packages/react/src/strength-indicator/types.ts
@@ -3,7 +3,7 @@ import { BaseProps } from '../_utils/props';
 
 export interface StrengthIndicatorProps
   extends BaseProps,
-    React.PropsWithRef<JSX.IntrinsicElements['div']> {
+    React.ComponentProps<'div'> {
   /** the number of indicator, default is 3 */
   blocks?: number;
 

--- a/packages/react/src/strength-indicator/types.ts
+++ b/packages/react/src/strength-indicator/types.ts
@@ -3,7 +3,7 @@ import { BaseProps } from '../_utils/props';
 
 export interface StrengthIndicatorProps
   extends BaseProps,
-    React.ComponentProps<'div'> {
+    React.ComponentPropsWithoutRef<'div'> {
   /** the number of indicator, default is 3 */
   blocks?: number;
 

--- a/packages/react/src/switch/types.ts
+++ b/packages/react/src/switch/types.ts
@@ -3,7 +3,7 @@ import { BaseProps, SizeType } from '../_utils/props';
 
 export interface SwitchProps
   extends BaseProps,
-    Omit<React.PropsWithRef<JSX.IntrinsicElements['label']>, 'onChange' | 'onClick'> {
+    Omit<React.ComponentProps<'label'>, 'onChange' | 'onClick'> {
   defaultChecked?: boolean;
   checked?: boolean;
   disabled?: boolean;

--- a/packages/react/src/switch/types.ts
+++ b/packages/react/src/switch/types.ts
@@ -3,7 +3,7 @@ import { BaseProps, SizeType } from '../_utils/props';
 
 export interface SwitchProps
   extends BaseProps,
-    Omit<React.ComponentProps<'label'>, 'onChange' | 'onClick'> {
+    Omit<React.ComponentPropsWithoutRef<'label'>, 'onChange' | 'onClick'> {
   defaultChecked?: boolean;
   checked?: boolean;
   disabled?: boolean;

--- a/packages/react/src/table/types.ts
+++ b/packages/react/src/table/types.ts
@@ -33,7 +33,7 @@ export interface TablePaginationConfig extends Pick<PaginationProps, 'size' | 'a
 
 export interface TableProps<T = any>
   extends BaseProps,
-    Omit<React.PropsWithoutRef<JSX.IntrinsicElements['div']>, 'onChange'> {
+    Omit<React.ComponentPropsWithoutRef<'div'>, 'onChange'> {
   columns: ColumnType<T>[];
   dataSource?: T[];
   rowKey?: string | ((record: T) => React.Key);

--- a/packages/react/src/tag/types.ts
+++ b/packages/react/src/tag/types.ts
@@ -29,7 +29,7 @@ export const PresetColors = [
   ...StatusColors,
 ];
 
-export interface TagProps extends BaseProps, React.PropsWithoutRef<JSX.IntrinsicElements['div']> {
+export interface TagProps extends BaseProps, React.ComponentPropsWithoutRef<'div'> {
   color?: string | StatusColor;
   variant?: TagVariant;
   closable?: boolean;

--- a/packages/react/src/text-loop/types.ts
+++ b/packages/react/src/text-loop/types.ts
@@ -3,7 +3,7 @@ import { BaseProps } from '../_utils/props';
 
 export interface TextLoopProps
   extends BaseProps,
-    React.PropsWithoutRef<JSX.IntrinsicElements['div']> {
+    React.ComponentPropsWithoutRef<'div'> {
   /** Time each item stays visible, in ms (default: 3000) */
   interval?: number;
   /** Pause cycling on hover (default: true) */

--- a/packages/react/src/timeline/types.ts
+++ b/packages/react/src/timeline/types.ts
@@ -5,14 +5,14 @@ export type TimelinePosition = 'left' | 'center';
 
 export interface TimelineProps
   extends BaseProps,
-    React.PropsWithoutRef<JSX.IntrinsicElements['ul']> {
+    React.ComponentPropsWithoutRef<'ul'> {
   position?: TimelinePosition;
   children: React.ReactNode;
 }
 
 export interface TimelineItemProps
   extends BaseProps,
-    React.PropsWithoutRef<JSX.IntrinsicElements['li']> {
+    React.ComponentPropsWithoutRef<'li'> {
   dot?: React.ReactNode;
   dotStyle?: CSSProperties;
   children?: React.ReactNode;

--- a/packages/react/src/transfer/transfer-panel.tsx
+++ b/packages/react/src/transfer/transfer-panel.tsx
@@ -11,7 +11,7 @@ import Input from '../input/input';
 
 export interface TransferPanelProps
   extends BaseProps,
-    Omit<React.PropsWithRef<JSX.IntrinsicElements['div']>, 'title' | 'onChange'> {
+    Omit<React.ComponentProps<'div'>, 'title' | 'onChange'> {
   dataSource: TransferItem[];
   checkedKeys: string[];
   onChange: (checkedKeys: string[]) => void;

--- a/packages/react/src/transfer/transfer-panel.tsx
+++ b/packages/react/src/transfer/transfer-panel.tsx
@@ -11,7 +11,7 @@ import Input from '../input/input';
 
 export interface TransferPanelProps
   extends BaseProps,
-    Omit<React.ComponentProps<'div'>, 'title' | 'onChange'> {
+    Omit<React.ComponentPropsWithoutRef<'div'>, 'title' | 'onChange'> {
   dataSource: TransferItem[];
   checkedKeys: string[];
   onChange: (checkedKeys: string[]) => void;

--- a/packages/react/src/transfer/types.ts
+++ b/packages/react/src/transfer/types.ts
@@ -9,7 +9,7 @@ export type TransferItem = {
 
 export interface TransferProps
   extends BaseProps,
-    Omit<React.ComponentProps<'div'>, 'onChange'> {
+    Omit<React.ComponentPropsWithoutRef<'div'>, 'onChange'> {
   dataSource?: TransferItem[];
   value?: string[];
   defaultValue?: string[];

--- a/packages/react/src/transfer/types.ts
+++ b/packages/react/src/transfer/types.ts
@@ -9,7 +9,7 @@ export type TransferItem = {
 
 export interface TransferProps
   extends BaseProps,
-    Omit<React.PropsWithRef<JSX.IntrinsicElements['div']>, 'onChange'> {
+    Omit<React.ComponentProps<'div'>, 'onChange'> {
   dataSource?: TransferItem[];
   value?: string[];
   defaultValue?: string[];

--- a/packages/react/src/tree/types.ts
+++ b/packages/react/src/tree/types.ts
@@ -12,7 +12,7 @@ export type TreeData = {
 
 export interface TreeProps
   extends BaseProps,
-    Omit<React.ComponentProps<'ul'>, 'onSelect'> {
+    Omit<React.ComponentPropsWithoutRef<'ul'>, 'onSelect'> {
   data?: TreeData[];
   indent?: number;
   checkable?: boolean;

--- a/packages/react/src/tree/types.ts
+++ b/packages/react/src/tree/types.ts
@@ -12,7 +12,7 @@ export type TreeData = {
 
 export interface TreeProps
   extends BaseProps,
-    Omit<React.PropsWithRef<JSX.IntrinsicElements['ul']>, 'onSelect'> {
+    Omit<React.ComponentProps<'ul'>, 'onSelect'> {
   data?: TreeData[];
   indent?: number;
   checkable?: boolean;

--- a/packages/react/src/typography/types.ts
+++ b/packages/react/src/typography/types.ts
@@ -30,11 +30,11 @@ export interface TypographyCopyableConfig {
 
 export interface TypographyProps
   extends BaseProps,
-    React.PropsWithRef<JSX.IntrinsicElements['div']> {
+    React.ComponentProps<'div'> {
   children?: React.ReactNode;
 }
 
-export interface ParagraphProps extends BaseProps, React.PropsWithRef<JSX.IntrinsicElements['p']> {
+export interface ParagraphProps extends BaseProps, React.ComponentProps<'p'> {
   as?: TypographyParagraphTag;
   ellipsis?: boolean | TypographyEllipsisConfig;
   children?: React.ReactNode;
@@ -42,12 +42,12 @@ export interface ParagraphProps extends BaseProps, React.PropsWithRef<JSX.Intrin
 
 export interface HeadingProps
   extends BaseProps,
-    React.PropsWithRef<React.HTMLAttributes<HTMLHeadingElement>> {
+    React.HTMLAttributes<HTMLHeadingElement> {
   level?: 1 | 2 | 3 | 4 | 5 | 6;
   children?: React.ReactNode;
 }
 
-export interface TextProps extends BaseProps, React.PropsWithRef<JSX.IntrinsicElements['span']> {
+export interface TextProps extends BaseProps, React.ComponentProps<'span'> {
   as?: TypographyTextTag;
   type?: TextType;
   copyable?: boolean | TypographyCopyableConfig;

--- a/packages/react/src/typography/types.ts
+++ b/packages/react/src/typography/types.ts
@@ -30,11 +30,11 @@ export interface TypographyCopyableConfig {
 
 export interface TypographyProps
   extends BaseProps,
-    React.ComponentProps<'div'> {
+    React.ComponentPropsWithoutRef<'div'> {
   children?: React.ReactNode;
 }
 
-export interface ParagraphProps extends BaseProps, React.ComponentProps<'p'> {
+export interface ParagraphProps extends BaseProps, React.ComponentPropsWithoutRef<'p'> {
   as?: TypographyParagraphTag;
   ellipsis?: boolean | TypographyEllipsisConfig;
   children?: React.ReactNode;
@@ -47,7 +47,7 @@ export interface HeadingProps
   children?: React.ReactNode;
 }
 
-export interface TextProps extends BaseProps, React.ComponentProps<'span'> {
+export interface TextProps extends BaseProps, React.ComponentPropsWithoutRef<'span'> {
   as?: TypographyTextTag;
   type?: TextType;
   copyable?: boolean | TypographyCopyableConfig;

--- a/packages/react/src/waterfall/types.ts
+++ b/packages/react/src/waterfall/types.ts
@@ -15,7 +15,7 @@ export interface WaterfallItem<T = any> {
 
 export interface WaterfallProps<T = any>
   extends BaseProps,
-    Omit<React.ComponentProps<'div'>, 'children'> {
+    Omit<React.ComponentPropsWithoutRef<'div'>, 'children'> {
   /** Number of columns, or responsive breakpoint config. Default: 3 */
   columns?: number | Partial<Record<Breakpoint, number>>;
   /** Spacing between items: number or [horizontal, vertical] */

--- a/packages/react/src/waterfall/types.ts
+++ b/packages/react/src/waterfall/types.ts
@@ -15,7 +15,7 @@ export interface WaterfallItem<T = any> {
 
 export interface WaterfallProps<T = any>
   extends BaseProps,
-    Omit<React.PropsWithRef<JSX.IntrinsicElements['div']>, 'children'> {
+    Omit<React.ComponentProps<'div'>, 'children'> {
   /** Number of columns, or responsive breakpoint config. Default: 3 */
   columns?: number | Partial<Record<Breakpoint, number>>;
   /** Spacing between items: number or [horizontal, vertical] */


### PR DESCRIPTION
## Summary

- Fixes #120. `React.PropsWithRef<JSX.IntrinsicElements['x']>` relied on the global `JSX` namespace, which `@types/react@19` no longer augments. Under React 19 the type collapsed to `any`, silently dropping `onClick`, `type`, `disabled`, `aria-*`, `children`, etc. from every affected component.
- Replaced the pattern with `React.ComponentProps<'x'>` / `React.ComponentPropsWithoutRef<'x'>` across ~60 type files.
- Works on React 18 and 19; `PropsWithRef`/`PropsWithoutRef` are deprecated no-op aliases in React 19 anyway, so the rewrite is also a cleanup.

## Notes on the reported issue

The issue's diagnosis ("`HTMLAttributes<T>` no longer includes `children`") is inaccurate — `DOMAttributes<T>` in `@types/react@19` still has `children`. The real cause is the missing global `JSX` namespace. The issue's suggested fix (adding `children` to `BaseProps`) would have masked the most visible symptom while leaving every other HTML prop still broken.

Reproduced against `@types/react@19.2.14` + `typescript@5.9.3` in a scratch workspace: the original pattern fails with `Cannot find namespace 'JSX'` and `Property 'onClick'/'type'/'disabled'/'children' does not exist`; the new pattern type-checks cleanly.

## Test plan

- [x] All 798 unit tests pass
- [x] No new `tsc --noEmit` errors in `packages/react` (10 pre-existing errors on master, unrelated)
- [x] Smoke-tested the new pattern against React 19.2.14 + TS 5.9.3 — intrinsic props (`onClick`, `type`, `disabled`, `aria-*`, `children`) all resolve
- [ ] Consumer on React 19 can pass `<Button variant="solid" onClick={...} disabled>...</Button>` without TS errors