### PR TITLE
feat(react): redesign skeleton animation api

### DIFF
--- a/.changeset/skeleton-animation-api-refresh.md
+++ b/.changeset/skeleton-animation-api-refresh.md
@@ -1,0 +1,6 @@
+---
+"@tiny-design/react": major
+"@tiny-design/tokens": major
+---
+
+Redesign Skeleton animation APIs, component structure, and related configuration.

--- a/packages/react/src/config-provider/config-context.tsx
+++ b/packages/react/src/config-provider/config-context.tsx
@@ -2,14 +2,19 @@ import React from 'react';
 import { SizeType } from '../_utils/props';
 import { SpaceSize } from '../space/types';
 import { Locale } from '../locale/types';
+import { SkeletonAnimation } from '../skeleton/types';
 import { ThemeConfig } from './token-utils';
 
 export type ThemeMode = 'light' | 'dark' | 'system';
 
+export interface SkeletonConfig {
+  animation?: SkeletonAnimation;
+}
+
 export interface ConfigContextProps {
   prefixCls?: string;
   componentSize?: SizeType;
-  shimmer?: boolean;
+  skeleton?: SkeletonConfig;
   space?: SpaceSize;
   theme?: ThemeMode;
   themeConfig?: ThemeConfig;
@@ -21,7 +26,7 @@ export interface ConfigContextProps {
 export const ConfigContext = React.createContext<ConfigContextProps>({
   prefixCls: 'ty',
   componentSize: 'md',
-  shimmer: false,
+  skeleton: undefined,
   space: 'sm',
   getPopupContainer: () => document.body,
   getTargetContainer: () => window,

--- a/packages/react/src/config-provider/config-provider.tsx
+++ b/packages/react/src/config-provider/config-provider.tsx
@@ -16,7 +16,7 @@ const ConfigProviderImpl = (props: ConfigProviderProps): React.ReactElement => {
     locale,
     prefixCls,
     componentSize,
-    shimmer,
+    skeleton,
     space,
     getPopupContainer,
     getTargetContainer,
@@ -49,7 +49,10 @@ const ConfigProviderImpl = (props: ConfigProviderProps): React.ReactElement => {
     () => ({
       prefixCls: prefixCls ?? parentConfig.prefixCls,
       componentSize: componentSize ?? parentConfig.componentSize,
-      shimmer: shimmer ?? parentConfig.shimmer,
+      skeleton: {
+        ...parentConfig.skeleton,
+        ...skeleton,
+      },
       space: space ?? parentConfig.space,
       theme: mode ?? parentConfig.theme,
       themeConfig: themeConfig ?? parentConfig.themeConfig,
@@ -65,7 +68,7 @@ const ConfigProviderImpl = (props: ConfigProviderProps): React.ReactElement => {
       mode,
       parentConfig,
       prefixCls,
-      shimmer,
+      skeleton,
       space,
       themeConfig,
     ]

--- a/packages/react/src/config-provider/index.md
+++ b/packages/react/src/config-provider/index.md
@@ -226,8 +226,8 @@ const { componentSize, getPopupContainer, locale } = ConfigProvider.useConfig();
 | ----------------- | ------------------------------------------------------------- | ------------------------------------------------- | --------- |
 | prefixCls         | set prefix class.                                             | string                                            | ty        |
 | componentSize     | component size.                                               | enum: `lg` &#124; `md` &#124; `sm`                | `md`      |
-| shimmer           | display shimmer effect for [Skeleton](#/components/skeleton). | boolean                                           | false     |
-| space             | set Space size, ref [Space](#/components/space).              | enum: `sm` &#124; `md` &#124; `lg` or `number`.   | `sm`      |
+| skeleton          | global config for [Skeleton](../components/skeleton), such as animation. | `{ animation?: false \| 'pulse' \| 'shimmer' }` | -         |
+| space             | set Space size, ref [Space](../components/space).              | enum: `sm` &#124; `md` &#124; `lg` or `number`.   | `sm`      |
 | locale            | set locale for components (e.g. `en_US`, `zh_CN`).           | Locale                                            | -         |
 | getPopupContainer | set the container for popup-based components within this provider scope. | `(trigger?: HTMLElement \| null) => HTMLElement` | provider popup holder |
 | getTargetContainer | set the default scroll target for components such as `Anchor`, `Sticky`, and `BackTop`, and the scroll-lock target for layers such as `Overlay` and `Tour`. | `() => HTMLElement \| Window`                    | `() => window` |

--- a/packages/react/src/config-provider/index.zh_CN.md
+++ b/packages/react/src/config-provider/index.zh_CN.md
@@ -226,8 +226,8 @@ const { componentSize, getPopupContainer, locale } = ConfigProvider.useConfig();
 | ----------------- | ------------------------------------------------------------- | ------------------------------------------------- | --------- |
 | prefixCls         | 设置类名前缀                                                  | string                                            | ty        |
 | componentSize     | 组件大小                                                      | enum: `lg` &#124; `md` &#124; `sm`                | `md`      |
-| shimmer           | 为 [Skeleton](#/components/skeleton) 显示微光动画效果         | boolean                                           | false     |
-| space             | 设置 Space 间距，参考 [Space](#/components/space)             | enum: `sm` &#124; `md` &#124; `lg` or `number`.   | `sm`      |
+| skeleton          | 为 [Skeleton](../components/skeleton) 提供全局配置，例如动画效果 | `{ animation?: false \| 'pulse' \| 'shimmer' }` | -         |
+| space             | 设置 Space 间距，参考 [Space](../components/space)             | enum: `sm` &#124; `md` &#124; `lg` or `number`.   | `sm`      |
 | locale            | 设置组件语言包（如 `en_US`、`zh_CN`）                         | Locale                                            | -         |
 | getPopupContainer | 为当前 provider 作用域内的弹层组件指定挂载容器               | `(trigger?: HTMLElement \| null) => HTMLElement`  | provider popup holder |
 | getTargetContainer | 为 `Anchor`、`Sticky`、`BackTop` 等组件设置默认滚动容器，同时为 `Overlay`、`Tour` 这类层级组件设置滚动锁目标 | `() => HTMLElement \| Window`                     | `() => window` |

--- a/packages/react/src/image/demo/Placeholder.tsx
+++ b/packages/react/src/image/demo/Placeholder.tsx
@@ -36,7 +36,7 @@ export default function PlaceholderDemo() {
         height={180}
         src={src}
         alt="Mountain lake"
-        placeholder={<Skeleton active style={{ width: '100%', height: '100%' }} />}
+        placeholder={<Skeleton animation="shimmer" width="100%" height="100%" />}
       />
     </Flex>
   );

--- a/packages/react/src/skeleton/__tests__/__snapshots__/skeleton.test.tsx.snap
+++ b/packages/react/src/skeleton/__tests__/__snapshots__/skeleton.test.tsx.snap
@@ -4,8 +4,12 @@ exports[`<Skeleton /> should match the snapshot 1`] = `
 <DocumentFragment>
   <div
     aria-busy="true"
-    class="ty-skeleton"
     role="status"
-  />
+  >
+    <div
+      aria-hidden="true"
+      class="ty-skeleton ty-skeleton_round"
+    />
+  </div>
 </DocumentFragment>
 `;

--- a/packages/react/src/skeleton/__tests__/skeleton.test.tsx
+++ b/packages/react/src/skeleton/__tests__/skeleton.test.tsx
@@ -10,21 +10,30 @@ describe('<Skeleton />', () => {
 
   it('should render correctly', () => {
     const { container } = render(<Skeleton />);
-    expect(container.firstChild).toHaveClass('ty-skeleton');
+    expect(container.firstChild).toHaveAttribute('role', 'status');
+    expect(container.querySelector('.ty-skeleton')).toBeInTheDocument();
+    expect(container.querySelector('.ty-skeleton')).toHaveClass('ty-skeleton_round');
   });
 
-  it('should render with active animation', () => {
-    const { container } = render(<Skeleton active />);
-    expect(container.firstChild).toHaveClass('ty-skeleton_active');
+  it('should render with shimmer animation', () => {
+    const { container } = render(<Skeleton animation="shimmer" />);
+    expect(container.querySelector('.ty-skeleton')).toHaveClass('ty-skeleton_animated_shimmer');
   });
 
-  it('should render rounded', () => {
-    const { container } = render(<Skeleton rounded />);
-    expect(container.firstChild).toHaveClass('ty-skeleton_rounded');
+  it('should render shaped block', () => {
+    const { container } = render(<Skeleton shape="circle" width={40} height={40} />);
+    expect(container.querySelector('.ty-skeleton')).toHaveClass('ty-skeleton_circle');
   });
 
-  it('should render children', () => {
-    const { getByText } = render(<Skeleton>Loading content</Skeleton>);
+  it('should render children when loading is false', () => {
+    const { getByText, queryByRole } = render(<Skeleton loading={false}>Loading content</Skeleton>);
     expect(getByText('Loading content')).toBeInTheDocument();
+    expect(queryByRole('status')).not.toBeInTheDocument();
+  });
+
+  it('should render structured skeleton', () => {
+    const { container } = render(<Skeleton avatar title paragraph={{ rows: 2 }} />);
+    expect(container.querySelector('.ty-skeleton__group')).toBeInTheDocument();
+    expect(container.querySelectorAll('.ty-skeleton__text-row')).toHaveLength(3);
   });
 });

--- a/packages/react/src/skeleton/demo/Active.tsx
+++ b/packages/react/src/skeleton/demo/Active.tsx
@@ -1,13 +1,24 @@
 import React from 'react';
-import { Skeleton } from '@tiny-design/react';
+import { Flex, Radio, Skeleton } from '@tiny-design/react';
+
+type AnimationMode = 'shimmer' | 'pulse';
 
 export default function ActiveDemo() {
+  const [animation, setAnimation] = React.useState<AnimationMode>('shimmer');
+
   return (
-    <>
-      <Skeleton active style={{ width: 300 }} />
-      <Skeleton active />
-      <Skeleton active />
-      <Skeleton active />
-    </>
+    <Flex vertical gap={16}>
+      <Radio.Group value={animation} onChange={(value) => setAnimation(value as AnimationMode)}>
+        <Radio value="shimmer">shimmer</Radio>
+        <Radio value="pulse">pulse</Radio>
+      </Radio.Group>
+
+      <div>
+        <Skeleton animation={animation} width={300} />
+        <Skeleton animation={animation} />
+        <Skeleton animation={animation} />
+        <Skeleton animation={animation} />
+      </div>
+    </Flex>
   );
 }

--- a/packages/react/src/skeleton/demo/Basic.tsx
+++ b/packages/react/src/skeleton/demo/Basic.tsx
@@ -4,7 +4,7 @@ import { Skeleton } from '@tiny-design/react';
 export default function BasicDemo() {
   return (
     <>
-      <Skeleton style={{ width: 300 }} />
+      <Skeleton width={300} />
       <Skeleton />
       <Skeleton />
       <Skeleton />

--- a/packages/react/src/skeleton/demo/Combination.tsx
+++ b/packages/react/src/skeleton/demo/Combination.tsx
@@ -1,25 +1,20 @@
 import React from 'react';
-import { Skeleton, ConfigProvider, Row, Col } from '@tiny-design/react';
+import { Skeleton, ConfigProvider, Flex } from '@tiny-design/react';
 
 export default function CombinationDemo() {
   return (
-    <ConfigProvider shimmer>
-      <Row>
-        <Col span={2}>
-          <Skeleton rounded style={{ width: 50, height: 50 }} />
-        </Col>
-        <Col span={22}>
+    <ConfigProvider skeleton={{ animation: 'shimmer' }}>
+      <Flex gap="sm" vertical>
+        <Flex gap="sm">
+          <Skeleton.Avatar size={50} />
           <div>
-            <Skeleton style={{ width: 300 }} />
+            <Skeleton width={300} />
+            <Skeleton width={300} />
           </div>
-          <div>
-            <Skeleton style={{ width: 300 }} />
-          </div>
-        </Col>
-      </Row>
-      <Skeleton />
-      <Skeleton />
-      <Skeleton />
+        </Flex>
+        <Skeleton title paragraph={{ rows: 2 }} />
+        <Skeleton title paragraph={{ rows: 4 }} />
+      </Flex>
     </ConfigProvider>
   );
 }

--- a/packages/react/src/skeleton/demo/Composed.tsx
+++ b/packages/react/src/skeleton/demo/Composed.tsx
@@ -1,0 +1,84 @@
+import React from 'react';
+import { Flex, Skeleton, useTheme } from '@tiny-design/react';
+
+export default function ComposedDemo() {
+  const { resolvedTheme } = useTheme();
+  const isDark = resolvedTheme === 'dark';
+
+  const shellStyle: React.CSSProperties = {
+    padding: 18,
+    border: `1px solid ${isDark ? '#303030' : '#e2e8f0'}`,
+    borderRadius: 20,
+    background: isDark
+      ? 'linear-gradient(180deg, #1f1f1f 0%, #262626 100%)'
+      : 'linear-gradient(180deg, #ffffff 0%, #f8fafc 100%)',
+    boxShadow: isDark ? 'none' : '0 10px 30px rgba(15, 23, 42, 0.04)',
+  };
+
+  const sectionLabelStyle: React.CSSProperties = {
+    marginBottom: 14,
+    fontSize: 11,
+    fontWeight: 700,
+    letterSpacing: '0.08em',
+    textTransform: 'uppercase',
+    color: isDark ? '#8f8f8f' : '#64748b',
+  };
+
+  const statCardStyle: React.CSSProperties = {
+    padding: 12,
+    border: `1px solid ${isDark ? '#3a3a3a' : '#e2e8f0'}`,
+    borderRadius: 16,
+    background: isDark ? '#242424' : 'rgba(255, 255, 255, 0.75)',
+  };
+
+  return (
+    <div style={shellStyle}>
+      <div style={sectionLabelStyle}>Profile Summary</div>
+      <Flex align="flex-start" gap={16}>
+        <Skeleton.Avatar size={64} animation="shimmer" />
+        <Flex vertical gap={14} style={{ flex: 1 }}>
+          <Flex justify="space-between" align="center" gap={12}>
+            <Skeleton.Text rows={1} width="42%" animation="shimmer" />
+            <Skeleton.Block shape="round" width={74} height={24} animation="pulse" />
+          </Flex>
+          <Skeleton.Text rows={2} widths={['96%', '58%']} animation="shimmer" />
+
+          <div
+            style={{
+              display: 'grid',
+              gridTemplateColumns: 'repeat(3, minmax(0, 1fr))',
+              gap: 12,
+            }}
+          >
+            <div style={statCardStyle}>
+              <Skeleton.Text rows={1} width="52%" animation="pulse" />
+              <div style={{ marginTop: 12 }}>
+                <Skeleton.Block shape="round" width="72%" height={28} animation="shimmer" />
+              </div>
+            </div>
+            <div style={statCardStyle}>
+              <Skeleton.Text rows={1} width="48%" animation="pulse" />
+              <div style={{ marginTop: 12 }}>
+                <Skeleton.Block shape="round" width="68%" height={28} animation="shimmer" />
+              </div>
+            </div>
+            <div style={statCardStyle}>
+              <Skeleton.Text rows={1} width="44%" animation="pulse" />
+              <div style={{ marginTop: 12 }}>
+                <Skeleton.Block shape="round" width="66%" height={28} animation="shimmer" />
+              </div>
+            </div>
+          </div>
+
+          <Flex justify="space-between" align="center" gap={12}>
+            <Skeleton.Text rows={1} width="32%" animation="pulse" />
+            <Flex gap={10}>
+              <Skeleton.Block shape="round" width={88} height={34} animation="pulse" />
+              <Skeleton.Block shape="round" width={112} height={34} animation="shimmer" />
+            </Flex>
+          </Flex>
+        </Flex>
+      </Flex>
+    </div>
+  );
+}

--- a/packages/react/src/skeleton/demo/Loading.tsx
+++ b/packages/react/src/skeleton/demo/Loading.tsx
@@ -1,0 +1,49 @@
+import React from 'react';
+import { Button, Card, Flex, Skeleton, Tag } from '@tiny-design/react';
+
+export default function LoadingDemo() {
+  const [loading, setLoading] = React.useState(true);
+
+  return (
+    <Flex vertical gap={12}>
+      <Button size="sm" onClick={() => setLoading((prev) => !prev)} style={{ alignSelf: 'flex-start' }}>
+        {loading ? 'Show content' : 'Show skeleton'}
+      </Button>
+      <Skeleton
+        loading={loading}
+        animation="shimmer"
+        avatar={{ size: 'lg' }}
+        title={{ width: '32%' }}
+        paragraph={{ rows: 3, widths: ['100%', '88%', '56%'] }}
+      >
+        <Card style={{ maxWidth: 520 }}>
+          <Card.Content>
+            <Flex vertical gap={12}>
+              <Flex justify="space-between" align="center">
+                <Flex align="center" gap={12}>
+                  <div
+                    style={{
+                      width: 48,
+                      height: 48,
+                      borderRadius: '50%',
+                      background: 'linear-gradient(135deg, #0f766e, #14b8a6)',
+                    }}
+                  />
+                  <div>
+                    <div style={{ fontWeight: 600 }}>API Sync Health</div>
+                    <div style={{ fontSize: 12, color: '#64748b' }}>Updated 2 minutes ago</div>
+                  </div>
+                </Flex>
+                <Tag color="success">Healthy</Tag>
+              </Flex>
+              <div style={{ color: '#475569', lineHeight: 1.6 }}>
+                14 upstream services are responding within the expected latency band. No manual action is
+                required for the current release window.
+              </div>
+            </Flex>
+          </Card.Content>
+        </Card>
+      </Skeleton>
+    </Flex>
+  );
+}

--- a/packages/react/src/skeleton/index.md
+++ b/packages/react/src/skeleton/index.md
@@ -4,6 +4,10 @@ import ActiveDemo from './demo/Active';
 import ActiveSource from './demo/Active.tsx?raw';
 import CombinationDemo from './demo/Combination';
 import CombinationSource from './demo/Combination.tsx?raw';
+import LoadingDemo from './demo/Loading';
+import LoadingSource from './demo/Loading.tsx?raw';
+import ComposedDemo from './demo/Composed';
+import ComposedSource from './demo/Composed.tsx?raw';
 
 # Skeleton
 
@@ -23,7 +27,9 @@ import { Skeleton } from '@tiny-design/react';
 
 ## Examples
 
-<Demo>
+<Layout>
+  <Column>
+    <Demo>
 
 ### Basic
 
@@ -31,31 +37,65 @@ Simplest Skeleton usage.
 
 <DemoBlock component={BasicDemo} source={BasicSource} />
 
-</Demo>
-<Demo>
+    </Demo>
+    <Demo>
 
-### Active
+### Animation
 
-Set `active={true}` to activate the Shimmer effect.
+Switch between `shimmer` and `pulse` to compare the two animation styles.
 
 <DemoBlock component={ActiveDemo} source={ActiveSource} />
 
-</Demo>
-<Demo>
+    </Demo>
+    <Demo>
 
-### Combination
+### Structured Skeleton
 
-A complex example.
+A structured loading placeholder.
 
-> Consider using `<ConfigProvider/>` to set `active` prop in once.
+> Consider using `<ConfigProvider skeleton={{ animation: 'shimmer' }} />` to set skeleton animation globally.
 
 <DemoBlock component={CombinationDemo} source={CombinationSource} />
 
-</Demo>
+    </Demo>
+  </Column>
+  <Column>
+    <Demo>
+
+### Loading Switch
+
+Use `loading` to switch between the skeleton state and the real content.
+
+<DemoBlock component={LoadingDemo} source={LoadingSource} />
+
+    </Demo>
+    <Demo>
+
+### Composed Blocks
+
+Use `Skeleton.Block`, `Skeleton.Text`, and `Skeleton.Avatar` to build custom loading layouts.
+
+<DemoBlock component={ComposedDemo} source={ComposedSource} />
+
+    </Demo>
+  </Column>
+</Layout>
 
 ## Props
 
-| Property          | Description                                       | Type                          | Default   |
-| ----------------- | ------------------------------------------------- | ----------------------------- | --------- |
-| active            | turn on Shimmer effect.                           | boolean                       | false     |
-| rounded           | display a circle skeleton                         | boolean                       | false     |
+| Property          | Description                                       | Type                              | Default   |
+| ----------------- | ------------------------------------------------- | --------------------------------- | --------- |
+| loading           | render skeleton or `children`                     | boolean                           | true      |
+| shape             | base skeleton shape                               | `rect` \| `round` \| `circle`     | `round`   |
+| width             | base skeleton width                               | string \| number                  | -         |
+| height            | base skeleton height                              | string \| number                  | -         |
+| animation         | animation style                                   | boolean \| `pulse` \| `shimmer`   | -         |
+| avatar            | render avatar skeleton or pass avatar config      | boolean \| object                 | false     |
+| title             | render title skeleton or pass title config        | boolean \| object                 | false     |
+| paragraph         | render paragraph skeleton or pass paragraph config | boolean \| object                | false     |
+
+## Subcomponents
+
+- `Skeleton.Block`: low-level placeholder block with `shape`, `width`, `height`, and `animation`
+- `Skeleton.Text`: text skeleton with `rows` and `widths`
+- `Skeleton.Avatar`: avatar skeleton with `shape` and `size`

--- a/packages/react/src/skeleton/index.zh_CN.md
+++ b/packages/react/src/skeleton/index.zh_CN.md
@@ -4,6 +4,10 @@ import ActiveDemo from './demo/Active';
 import ActiveSource from './demo/Active.tsx?raw';
 import CombinationDemo from './demo/Combination';
 import CombinationSource from './demo/Combination.tsx?raw';
+import LoadingDemo from './demo/Loading';
+import LoadingSource from './demo/Loading.tsx?raw';
+import ComposedDemo from './demo/Composed';
+import ComposedSource from './demo/Composed.tsx?raw';
 
 # Skeleton 骨架屏
 
@@ -23,7 +27,9 @@ import { Skeleton } from '@tiny-design/react';
 
 ## 代码示例
 
-<Demo>
+<Layout>
+  <Column>
+    <Demo>
 
 ### 基础用法
 
@@ -31,31 +37,65 @@ import { Skeleton } from '@tiny-design/react';
 
 <DemoBlock component={BasicDemo} source={BasicSource} />
 
-</Demo>
-<Demo>
+    </Demo>
+    <Demo>
 
-### 动画效果
+### 动画参数
 
-设置 `active={true}` 开启微光动画效果。
+切换 `shimmer` 和 `pulse`，对比两种动画效果。
 
 <DemoBlock component={ActiveDemo} source={ActiveSource} />
 
-</Demo>
-<Demo>
+    </Demo>
+    <Demo>
 
-### 组合使用
+### 结构化骨架
 
-一个复杂示例。
+一个结构化的加载占位示例。
 
-> 可以使用 `<ConfigProvider/>` 一次性设置 `shimmer` 属性。
+> 可以使用 `<ConfigProvider skeleton={{ animation: 'shimmer' }} />` 一次性设置骨架屏动画。
 
 <DemoBlock component={CombinationDemo} source={CombinationSource} />
 
-</Demo>
+    </Demo>
+  </Column>
+  <Column>
+    <Demo>
+
+### 加载态切换
+
+通过 `loading` 在骨架屏和真实内容之间切换。
+
+<DemoBlock component={LoadingDemo} source={LoadingSource} />
+
+    </Demo>
+    <Demo>
+
+### 组合式搭建
+
+使用 `Skeleton.Block`、`Skeleton.Text`、`Skeleton.Avatar` 自定义更复杂的加载结构。
+
+<DemoBlock component={ComposedDemo} source={ComposedSource} />
+
+    </Demo>
+  </Column>
+</Layout>
 
 ## Props
 
-| 属性              | 说明                                      | 类型                          | 默认值    |
-| ----------------- | ----------------------------------------- | ----------------------------- | --------- |
-| active            | 是否开启微光动画效果                      | boolean                       | false     |
-| rounded           | 是否显示为圆形骨架屏                      | boolean                       | false     |
+| 属性              | 说明                                      | 类型                                | 默认值    |
+| ----------------- | ----------------------------------------- | ----------------------------------- | --------- |
+| loading           | 是否显示骨架屏；为 `false` 时渲染 `children` | boolean                           | true      |
+| shape             | 基础骨架形状                              | `rect` \| `round` \| `circle`       | `round`   |
+| width             | 基础骨架宽度                              | string \| number                    | -         |
+| height            | 基础骨架高度                              | string \| number                    | -         |
+| animation         | 动画效果                                  | boolean \| `pulse` \| `shimmer`     | -         |
+| avatar            | 是否显示头像骨架，或传入头像配置          | boolean \| object                   | false     |
+| title             | 是否显示标题骨架，或传入标题配置          | boolean \| object                   | false     |
+| paragraph         | 是否显示段落骨架，或传入段落配置          | boolean \| object                   | false     |
+
+## 子组件
+
+- `Skeleton.Block`: 低层占位块，可单独控制 `shape`、`width`、`height`、`animation`
+- `Skeleton.Text`: 文本行骨架，支持 `rows` 和 `widths`
+- `Skeleton.Avatar`: 头像骨架，支持 `shape` 和 `size`

--- a/packages/react/src/skeleton/skeleton.tsx
+++ b/packages/react/src/skeleton/skeleton.tsx
@@ -2,33 +2,278 @@ import React, { useContext } from 'react';
 import classNames from 'classnames';
 import { ConfigContext } from '../config-provider/config-context';
 import { getPrefixCls } from '../_utils/general';
-import { SkeletonProps } from './types';
+import {
+  SkeletonAnimation,
+  SkeletonAvatarProps,
+  SkeletonBlockProps,
+  SkeletonProps,
+  SkeletonSize,
+  SkeletonTextProps,
+} from './types';
 
-const Skeleton = React.memo(React.forwardRef<HTMLDivElement, SkeletonProps>(
-  (props: SkeletonProps, ref): JSX.Element => {
+const getAnimationName = (
+  animation: SkeletonAnimation | undefined,
+  configAnimation: SkeletonAnimation | undefined
+): 'pulse' | 'shimmer' | null => {
+  if (animation === false) {
+    return null;
+  }
+
+  if (animation === 'pulse' || animation === 'shimmer') {
+    return animation;
+  }
+
+  if (animation === true) {
+    return 'shimmer';
+  }
+
+  if (configAnimation === 'pulse' || configAnimation === 'shimmer') {
+    return configAnimation;
+  }
+
+  return null;
+};
+
+const getBlockStyle = (
+  style: React.CSSProperties | undefined,
+  width?: number | string,
+  height?: number | string
+): React.CSSProperties | undefined => {
+  if (width === undefined && height === undefined) {
+    return style;
+  }
+
+  return {
+    ...style,
+    ...(width !== undefined ? { width } : null),
+    ...(height !== undefined ? { height } : null),
+  };
+};
+
+const getAvatarSize = (size: SkeletonSize | undefined): number => {
+  if (typeof size === 'number') {
+    return size;
+  }
+
+  switch (size) {
+    case 'sm':
+      return 32;
+    case 'lg':
+      return 48;
+    case 'md':
+    default:
+      return 40;
+  }
+};
+
+const SkeletonBlock = React.memo(React.forwardRef<HTMLDivElement, SkeletonBlockProps>(
+  (props: SkeletonBlockProps, ref): JSX.Element => {
     const {
-      active = false,
-      rounded = false,
       className,
-      children,
+      style,
       prefixCls: customisedCls,
+      shape = 'round',
+      width,
+      height,
+      animation,
       ...otherProps
     } = props;
     const configContext = useContext(ConfigContext);
     const prefixCls = getPrefixCls('skeleton', configContext.prefixCls, customisedCls);
+    const animationName = getAnimationName(animation, configContext.skeleton?.animation);
     const cls = classNames(prefixCls, className, {
-      [`${prefixCls}_active`]: configContext.shimmer || active,
-      [`${prefixCls}_rounded`]: rounded,
+      [`${prefixCls}_${shape}`]: shape !== 'rect',
+      [`${prefixCls}_animated`]: Boolean(animationName),
+      [`${prefixCls}_animated_${animationName}`]: Boolean(animationName),
     });
 
     return (
-      <div ref={ref} {...otherProps} className={cls} role="status" aria-busy="true">
-        {children}
+      <div
+        ref={ref}
+        {...otherProps}
+        className={cls}
+        style={getBlockStyle(style, width, height)}
+        aria-hidden="true"
+      />
+    );
+  }
+));
+
+SkeletonBlock.displayName = 'SkeletonBlock';
+
+const SkeletonText = React.memo(React.forwardRef<HTMLDivElement, SkeletonTextProps>(
+  (props: SkeletonTextProps, ref): JSX.Element => {
+    const {
+      rows = 1,
+      widths,
+      className,
+      prefixCls: customisedCls,
+      shape = 'round',
+      width,
+      height = '1em',
+      ...otherProps
+    } = props;
+    const configContext = useContext(ConfigContext);
+    const prefixCls = getPrefixCls('skeleton', configContext.prefixCls, customisedCls);
+    const items = Array.from({ length: Math.max(1, rows) }, (_, index) => {
+      const rowWidth = widths?.[index] ?? (index === rows - 1 && rows > 1 ? '61%' : width);
+
+      return (
+        <SkeletonBlock
+          key={index}
+          {...otherProps}
+          shape={shape}
+          width={rowWidth}
+          height={height}
+          className={`${prefixCls}__text-row`}
+        />
+      );
+    });
+
+    return (
+      <div ref={ref} className={classNames(`${prefixCls}__text`, className)} aria-hidden="true">
+        {items}
       </div>
     );
   }
 ));
 
-Skeleton.displayName = 'Skeleton';
+SkeletonText.displayName = 'SkeletonText';
+
+const SkeletonAvatar = React.memo(React.forwardRef<HTMLDivElement, SkeletonAvatarProps>(
+  (props: SkeletonAvatarProps, ref): JSX.Element => {
+    const {
+      size = 'md',
+      shape = 'circle',
+      className,
+      prefixCls: customisedCls,
+      ...otherProps
+    } = props;
+    const configContext = useContext(ConfigContext);
+    const prefixCls = getPrefixCls('skeleton', configContext.prefixCls, customisedCls);
+    const dimension = getAvatarSize(size);
+
+    return (
+      <SkeletonBlock
+        ref={ref}
+        {...otherProps}
+        prefixCls={customisedCls}
+        width={dimension}
+        height={dimension}
+        shape={shape === 'square' ? 'round' : 'circle'}
+        className={classNames(`${prefixCls}__avatar`, className)}
+      />
+    );
+  }
+));
+
+SkeletonAvatar.displayName = 'SkeletonAvatar';
+
+type SkeletonComponent = React.MemoExoticComponent<
+  React.ForwardRefExoticComponent<SkeletonProps & React.RefAttributes<HTMLDivElement>>
+> & {
+  Block: typeof SkeletonBlock;
+  Text: typeof SkeletonText;
+  Avatar: typeof SkeletonAvatar;
+};
+
+const SkeletonBase = React.memo(React.forwardRef<HTMLDivElement, SkeletonProps>(
+  (props: SkeletonProps, ref): JSX.Element | null => {
+    const {
+      loading = true,
+      avatar = false,
+      title = false,
+      paragraph = false,
+      children,
+      className,
+      prefixCls: customisedCls,
+      shape = 'round',
+      width,
+      height,
+      animation,
+      style,
+      ...otherProps
+    } = props;
+    const configContext = useContext(ConfigContext);
+    const prefixCls = getPrefixCls('skeleton', configContext.prefixCls, customisedCls);
+
+    if (!loading) {
+      return children ? <>{children}</> : null;
+    }
+
+    const hasStructuredContent = avatar || title || paragraph;
+
+    if (!hasStructuredContent) {
+      return (
+        <div ref={ref} {...otherProps} role="status" aria-busy="true">
+          <SkeletonBlock
+            prefixCls={customisedCls}
+            shape={shape}
+            width={width}
+            height={height}
+            animation={animation}
+            style={style}
+            className={className}
+          />
+        </div>
+      );
+    }
+
+    const avatarConfig = avatar && typeof avatar === 'object' ? avatar : undefined;
+    const titleConfig = title && typeof title === 'object' ? title : undefined;
+    const paragraphConfig = paragraph && typeof paragraph === 'object' ? paragraph : undefined;
+    const rows = paragraph === false ? 0 : paragraphConfig?.rows ?? 3;
+
+    return (
+      <div
+        ref={ref}
+        {...otherProps}
+        className={classNames(`${prefixCls}__group`, className, {
+          [`${prefixCls}__group_with-avatar`]: avatar,
+        })}
+        style={style}
+        role="status"
+        aria-busy="true"
+      >
+        {avatar && (
+          <SkeletonAvatar
+            prefixCls={customisedCls}
+            animation={animation}
+            size={avatarConfig?.size}
+            shape={avatarConfig?.shape}
+          />
+        )}
+        <div className={`${prefixCls}__content`}>
+          {title && (
+            <SkeletonText
+              prefixCls={customisedCls}
+              animation={animation}
+              rows={1}
+              width={titleConfig?.width ?? '38%'}
+              className={`${prefixCls}__title`}
+            />
+          )}
+          {rows > 0 && (
+            <SkeletonText
+              prefixCls={customisedCls}
+              animation={animation}
+              rows={rows}
+              widths={paragraphConfig?.widths}
+              className={`${prefixCls}__paragraph`}
+            />
+          )}
+        </div>
+      </div>
+    );
+  }
+));
+
+SkeletonBase.displayName = 'Skeleton';
+
+const Skeleton = Object.assign(SkeletonBase, {
+  Block: SkeletonBlock,
+  Text: SkeletonText,
+  Avatar: SkeletonAvatar,
+}) as SkeletonComponent;
 
 export default Skeleton;

--- a/packages/react/src/skeleton/style/index.scss
+++ b/packages/react/src/skeleton/style/index.scss
@@ -8,32 +8,92 @@
   overflow: hidden;
   background-color: var(--ty-skeleton-bg);
 
-  & + & {
-    margin-top: var(--ty-skeleton-stack-gap);
-  }
-
   &::after {
     position: absolute;
     inset: 0;
-    transform: translateX(-100%);
-    background-image: var(--ty-skeleton-shimmer);
-    background-size: 200% 100%;
-    animation: ty-shimmer var(--ty-skeleton-animation-duration) ease infinite;
+    pointer-events: none;
   }
 
-  &_rounded {
+  &_round {
+    border-radius: var(--ty-skeleton-radius-round);
+  }
+
+  &_circle {
     border-radius: 50%;
   }
 
-  &_active {
+  &_animated_shimmer {
     &::after {
       content: '';
+      transform: translateX(-100%);
+      background-image: var(--ty-skeleton-shimmer);
+      background-size: 200% 100%;
+      animation: ty-skeleton-shimmer var(--ty-skeleton-animation-duration) ease infinite;
     }
+  }
+
+  &_animated_pulse {
+    animation: ty-skeleton-pulse var(--ty-skeleton-animation-duration) ease-in-out infinite;
+  }
+
+  &__group {
+    display: flex;
+    align-items: flex-start;
+    gap: var(--ty-skeleton-block-gap);
+  }
+
+  &__content {
+    display: flex;
+    flex-direction: column;
+    gap: var(--ty-skeleton-block-gap);
+    flex: 1;
+    min-width: 0;
+  }
+
+  &__text {
+    display: flex;
+    flex-direction: column;
+    gap: var(--ty-skeleton-row-gap);
+  }
+
+  &__title {
+    margin-bottom: 0;
+  }
+
+  &__paragraph {
+    width: 100%;
+  }
+
+  &__text-row {
+    display: block;
+  }
+
+  &__avatar {
+    flex: none;
   }
 }
 
-@keyframes ty-shimmer {
+@keyframes ty-skeleton-shimmer {
   100% {
     transform: translateX(100%);
+  }
+}
+
+@keyframes ty-skeleton-pulse {
+  0%,
+  100% {
+    opacity: 1;
+  }
+
+  50% {
+    opacity: 0.5;
+  }
+}
+
+.#{$prefix}-skeleton__group {
+  .#{$prefix}-skeleton {
+    & + & {
+      margin-top: 0;
+    }
   }
 }

--- a/packages/react/src/skeleton/types.ts
+++ b/packages/react/src/skeleton/types.ts
@@ -1,8 +1,51 @@
 import React from 'react';
 import { BaseProps } from '../_utils/props';
 
-export interface SkeletonProps extends BaseProps, React.ComponentPropsWithoutRef<'div'> {
-  active?: boolean;
-  rounded?: boolean;
+export type SkeletonShape = 'rect' | 'round' | 'circle';
+export type SkeletonAnimation = boolean | 'pulse' | 'shimmer';
+export type SkeletonSize = 'sm' | 'md' | 'lg' | number;
+
+export interface SkeletonAvatarConfig {
+  shape?: 'circle' | 'square';
+  size?: SkeletonSize;
+}
+
+export interface SkeletonTitleConfig {
+  width?: number | string;
+}
+
+export interface SkeletonParagraphConfig {
+  rows?: number;
+  widths?: Array<number | string>;
+}
+
+export interface SkeletonBlockProps
+  extends BaseProps,
+    Omit<React.ComponentPropsWithoutRef<'div'>, 'children' | 'title'> {
+  shape?: SkeletonShape;
+  width?: number | string;
+  height?: number | string;
+  animation?: SkeletonAnimation;
+}
+
+export interface SkeletonTextProps extends SkeletonBlockProps {
+  rows?: number;
+  widths?: Array<number | string>;
+}
+
+export interface SkeletonAvatarProps extends Omit<SkeletonBlockProps, 'shape' | 'width' | 'height'> {
+  shape?: 'circle' | 'square';
+  size?: SkeletonSize;
+}
+
+export interface SkeletonProps extends Omit<React.ComponentPropsWithoutRef<'div'>, 'title'>, BaseProps {
+  loading?: boolean;
+  shape?: SkeletonShape;
+  width?: number | string;
+  height?: number | string;
+  animation?: SkeletonAnimation;
+  avatar?: boolean | SkeletonAvatarConfig;
+  title?: boolean | SkeletonTitleConfig;
+  paragraph?: boolean | SkeletonParagraphConfig;
   children?: React.ReactNode;
 }

--- a/packages/react/src/statistic/statistic.tsx
+++ b/packages/react/src/statistic/statistic.tsx
@@ -374,20 +374,16 @@ const Statistic = React.forwardRef<HTMLDivElement, StatisticProps>((props, ref) 
     skeleton || (
       <div className={`${prefixCls}__skeleton`} aria-hidden="true">
         <Skeleton
-          active
-          style={{
-            width: size === 'sm' ? 64 : 72,
-            height: 12,
-            borderRadius: 6,
-          }}
+          animation="shimmer"
+          shape="round"
+          width={size === 'sm' ? 64 : 72}
+          height={12}
         />
         <Skeleton
-          active
-          style={{
-            width: size === 'lg' ? 192 : 156,
-            height: size === 'lg' ? 36 : 28,
-            borderRadius: 8,
-          }}
+          animation="shimmer"
+          shape="round"
+          width={size === 'lg' ? 192 : 156}
+          height={size === 'lg' ? 36 : 28}
         />
       </div>
     )

--- a/packages/tokens/source/components/skeleton.json
+++ b/packages/tokens/source/components/skeleton.json
@@ -9,10 +9,20 @@
     "$type": "dimension",
     "description": "Skeleton default height."
   },
-  "skeleton.stack-gap": {
+  "skeleton.row-gap": {
     "$value": "10px",
     "$type": "dimension",
-    "description": "Skeleton vertical stack gap."
+    "description": "Skeleton row gap."
+  },
+  "skeleton.radius-round": {
+    "$value": "999px",
+    "$type": "dimension",
+    "description": "Skeleton rounded rectangle radius."
+  },
+  "skeleton.block-gap": {
+    "$value": "8px",
+    "$type": "dimension",
+    "description": "Skeleton structured block gap."
   },
   "skeleton.shimmer": {
     "$value": "linear-gradient(to right, #f2f2f2 25%, #e6e6e6 37%, #f2f2f2 63%)",


### PR DESCRIPTION
## Summary
- redesign Skeleton into a richer loading primitive with structured layouts and subcomponents
- replace the old ConfigProvider shimmer setting with skeleton.animation and update related docs and demos
- add a major changeset for the react and tokens packages

## Release
- major
- affected packages: react, tokens

## Test plan
- pnpm --filter @tiny-design/react test -- skeleton config-provider
- pnpm --filter @tiny-design/react exec tsc -p tsconfig.json --noEmit
- verified Skeleton docs page in browser, including dark mode