### PR TITLE
fix(react): migrate runtime component checks to markers

### DIFF
--- a/.changeset/fix-react-runtime-markers.md
+++ b/.changeset/fix-react-runtime-markers.md
@@ -1,0 +1,5 @@
+---
+"@tiny-design/react": patch
+---
+
+Replace runtime displayName checks with component markers for React component composition and keep displayName for debugging only.

--- a/packages/react/src/_utils/component-markers.ts
+++ b/packages/react/src/_utils/component-markers.ts
@@ -1,0 +1,31 @@
+export const INPUT_GROUP_CONTROL_MARK = Symbol('tiny-design.input-group-control');
+export const SELECT_MARK = Symbol('tiny-design.select');
+export const SELECT_OPTION_MARK = Symbol('tiny-design.select-option');
+export const SELECT_OPT_GROUP_MARK = Symbol('tiny-design.select-opt-group');
+export const MENU_MARK = Symbol('tiny-design.menu');
+export const MENU_ITEM_MARK = Symbol('tiny-design.menu-item');
+export const SUB_MENU_MARK = Symbol('tiny-design.sub-menu');
+export const MENU_ITEM_GROUP_MARK = Symbol('tiny-design.menu-item-group');
+export const MENU_DIVIDER_MARK = Symbol('tiny-design.menu-divider');
+export const ANCHOR_LINK_MARK = Symbol('tiny-design.anchor-link');
+export const STEPS_ITEM_MARK = Symbol('tiny-design.steps-item');
+export const TIMELINE_ITEM_MARK = Symbol('tiny-design.timeline-item');
+export const CARD_CONTENT_MARK = Symbol('tiny-design.card-content');
+export const FLIP_ITEM_MARK = Symbol('tiny-design.flip-item');
+export const AVATAR_MARK = Symbol('tiny-design.avatar');
+
+type Marker = symbol;
+type Markable = Record<PropertyKey, unknown>;
+
+export function markComponent<T extends object>(component: T, marker: Marker): T {
+  (component as T & Markable)[marker] = true;
+  return component;
+}
+
+export function hasMarker(type: unknown, marker: Marker): boolean {
+  if (!type || (typeof type !== 'function' && typeof type !== 'object')) {
+    return false;
+  }
+
+  return Boolean((type as Markable)[marker]);
+}

--- a/packages/react/src/anchor/__tests__/anchor.test.tsx
+++ b/packages/react/src/anchor/__tests__/anchor.test.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { render } from '@testing-library/react';
+import { ANCHOR_LINK_MARK, markComponent } from '../../_utils/component-markers';
 import Anchor from '../index';
 
 describe('<Anchor />', () => {
@@ -31,6 +32,21 @@ describe('<Anchor />', () => {
     );
     expect(getByText('Link 1')).toBeInTheDocument();
     expect(getByText('Link 2')).toBeInTheDocument();
+  });
+
+  it('should recognize marker-based link wrappers', () => {
+    const WrappedLink = markComponent(
+      (props: React.ComponentProps<typeof Anchor.Link>) => <Anchor.Link {...props} />,
+      ANCHOR_LINK_MARK
+    );
+
+    const { getByText } = render(
+      <Anchor>
+        <WrappedLink href="#s1" title="Wrapped Link" />
+      </Anchor>
+    );
+
+    expect(getByText('Wrapped Link')).toBeInTheDocument();
   });
 
   it('should forward ref to root list element', () => {

--- a/packages/react/src/anchor/anchor-link.tsx
+++ b/packages/react/src/anchor/anchor-link.tsx
@@ -1,5 +1,6 @@
 import React, { useContext, useEffect } from 'react';
 import classNames from 'classnames';
+import { ANCHOR_LINK_MARK, markComponent } from '../_utils/component-markers';
 import { AnchorLinkProps } from './types';
 import { AnchorContext } from './anchor-context';
 
@@ -50,5 +51,6 @@ const AnchorLink = React.forwardRef<HTMLAnchorElement, AnchorLinkProps>(
 );
 
 AnchorLink.displayName = 'AnchorLink';
+markComponent(AnchorLink, ANCHOR_LINK_MARK);
 
 export default AnchorLink;

--- a/packages/react/src/anchor/anchor.tsx
+++ b/packages/react/src/anchor/anchor.tsx
@@ -1,5 +1,6 @@
 import React, { useContext, useState, useCallback, useEffect, useRef, useMemo } from 'react';
 import classNames from 'classnames';
+import { ANCHOR_LINK_MARK, hasMarker } from '../_utils/component-markers';
 import { ConfigContext } from '../config-provider/config-context';
 import { resolveTargetContainer } from '../config-provider/container-utils';
 import { getPrefixCls } from '../_utils/general';
@@ -228,7 +229,7 @@ const Anchor = React.forwardRef<HTMLUListElement, AnchorProps>((props, ref): JSX
       </div>
       {React.Children.map(children, (child) => {
         const childElement = child as React.FunctionComponentElement<AnchorLinkProps>;
-        if (childElement.type.displayName === 'AnchorLink') {
+        if (hasMarker(childElement.type, ANCHOR_LINK_MARK)) {
           const childProps: Partial<AnchorLinkProps> = {
             prefixCls,
           };

--- a/packages/react/src/avatar/__tests__/avatar.test.tsx
+++ b/packages/react/src/avatar/__tests__/avatar.test.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { render } from '@testing-library/react';
+import { AVATAR_MARK, markComponent } from '../../_utils/component-markers';
 import Avatar from '../index';
 
 describe('<Avatar />', () => {
@@ -36,5 +37,23 @@ describe('<Avatar />', () => {
   it('should render with custom size', () => {
     const { container } = render(<Avatar size={50}>A</Avatar>);
     expect(container.firstChild).toHaveStyle({ width: '50px', height: '50px' });
+  });
+
+  it('should recognize marker-based avatar wrappers in Avatar.Group', () => {
+    const WrappedAvatar = markComponent(
+      (props: React.ComponentProps<typeof Avatar>) => <Avatar {...props} />,
+      AVATAR_MARK
+    );
+
+    const { container } = render(
+      <Avatar.Group gap={-10}>
+        <WrappedAvatar>A</WrappedAvatar>
+        <WrappedAvatar>B</WrappedAvatar>
+      </Avatar.Group>
+    );
+
+    const avatars = container.querySelectorAll('.ty-avatar');
+    expect(avatars).toHaveLength(2);
+    expect(avatars[1]).toHaveStyle({ marginLeft: '-10px' });
   });
 });

--- a/packages/react/src/avatar/avatar-group.tsx
+++ b/packages/react/src/avatar/avatar-group.tsx
@@ -1,5 +1,6 @@
 import React, { useContext } from 'react';
 import classNames from 'classnames';
+import { AVATAR_MARK, hasMarker } from '../_utils/component-markers';
 import { ConfigContext } from '../config-provider/config-context';
 import { getPrefixCls } from '../_utils/general';
 import { AvatarProps, AvatarGroupProps } from './types';
@@ -14,7 +15,7 @@ const AvatarGroup = (props: AvatarGroupProps): JSX.Element => {
     <span {...otherProps} className={cls} style={style}>
       {React.Children.map(children, (child, idx) => {
         const childElement = child as React.FunctionComponentElement<AvatarProps>;
-        if (childElement.type.displayName === 'Avatar') {
+        if (hasMarker(childElement.type, AVATAR_MARK)) {
           const childProps: Partial<AvatarProps> = {
             style: {
               ...childElement.props.style,

--- a/packages/react/src/avatar/avatar.tsx
+++ b/packages/react/src/avatar/avatar.tsx
@@ -1,5 +1,6 @@
 import React, { useRef, useEffect, useState, useContext } from 'react';
 import classNames from 'classnames';
+import { AVATAR_MARK, markComponent } from '../_utils/component-markers';
 import { ConfigContext } from '../config-provider/config-context';
 import { getPrefixCls } from '../_utils/general';
 import { AvatarProps } from './types';
@@ -98,5 +99,6 @@ const Avatar = React.forwardRef<HTMLSpanElement, AvatarProps>((props, ref) => {
 });
 
 Avatar.displayName = 'Avatar';
+markComponent(Avatar, AVATAR_MARK);
 
 export default Avatar;

--- a/packages/react/src/button/button.tsx
+++ b/packages/react/src/button/button.tsx
@@ -1,5 +1,6 @@
 import React, { useContext } from 'react';
 import classNames from 'classnames';
+import { INPUT_GROUP_CONTROL_MARK, markComponent } from '../_utils/component-markers';
 import { ConfigContext } from '../config-provider/config-context';
 import { getPrefixCls } from '../_utils/general';
 import { ButtonProps } from './types';
@@ -93,6 +94,7 @@ const Button = React.forwardRef<HTMLButtonElement, ButtonProps>((props: ButtonPr
 });
 
 Button.displayName = 'Button';
-(Button as typeof Button & { [BUTTON_MARK]?: boolean })[BUTTON_MARK] = true;
+markComponent(Button, BUTTON_MARK);
+markComponent(Button, INPUT_GROUP_CONTROL_MARK);
 
 export default Button;

--- a/packages/react/src/card/__tests__/card.test.tsx
+++ b/packages/react/src/card/__tests__/card.test.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { render } from '@testing-library/react';
+import { CARD_CONTENT_MARK, markComponent } from '../../_utils/component-markers';
 import Card from '../index';
 
 describe('<Card />', () => {
@@ -64,5 +65,20 @@ describe('<Card />', () => {
   it('should render footer', () => {
     const { getByText } = render(<Card footer={<div>Footer</div>}>Content</Card>);
     expect(getByText('Footer')).toBeInTheDocument();
+  });
+
+  it('should recognize marker-based card content wrappers', () => {
+    const WrappedContent = markComponent(
+      (props: React.ComponentProps<typeof Card.Content>) => <Card.Content {...props} />,
+      CARD_CONTENT_MARK
+    );
+
+    const { container } = render(
+      <Card>
+        <WrappedContent>Wrapped body</WrappedContent>
+      </Card>
+    );
+
+    expect(container.querySelector('.ty-card__body')).toHaveTextContent('Wrapped body');
   });
 });

--- a/packages/react/src/card/card-content.tsx
+++ b/packages/react/src/card/card-content.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { CARD_CONTENT_MARK, markComponent } from '../_utils/component-markers';
 import { CardContentProps } from './types';
 
 const CardContent = (props: CardContentProps): React.ReactElement => {
@@ -11,5 +12,6 @@ const CardContent = (props: CardContentProps): React.ReactElement => {
 };
 
 CardContent.displayName = 'CardContent';
+markComponent(CardContent, CARD_CONTENT_MARK);
 
 export default CardContent;

--- a/packages/react/src/card/card.tsx
+++ b/packages/react/src/card/card.tsx
@@ -1,5 +1,6 @@
 import React, { ReactNode, useContext } from 'react';
 import classNames from 'classnames';
+import { CARD_CONTENT_MARK, hasMarker } from '../_utils/component-markers';
 import { ConfigContext } from '../config-provider/config-context';
 import { getPrefixCls } from '../_utils/general';
 import { CardContentProps, CardProps, CardVariant } from './types';
@@ -72,7 +73,7 @@ const Card = React.forwardRef<HTMLDivElement, CardProps>((props, ref) => {
 
         // Pass prefixCls attribute to child if it is a CardContent instance
         const childElement = child as React.FunctionComponentElement<CardContentProps>;
-        if (childElement.type.displayName === 'CardContent') {
+        if (hasMarker(childElement.type, CARD_CONTENT_MARK)) {
           const childProps: Partial<CardContentProps> = {
             prefixCls,
           };

--- a/packages/react/src/dropdown/__tests__/dropdown.test.tsx
+++ b/packages/react/src/dropdown/__tests__/dropdown.test.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { markComponent, MENU_MARK } from '../../_utils/component-markers';
 import Dropdown from '../index';
 import Menu from '../../menu';
 
@@ -74,6 +75,33 @@ describe('<Dropdown />', () => {
           <Menu>
             <Menu.Item>Menu Item</Menu.Item>
           </Menu>
+        }
+      >
+        <button>Trigger</button>
+      </Dropdown>
+    );
+
+    fireEvent.click(screen.getByText('Trigger'));
+
+    await waitFor(() => {
+      expect(screen.getByRole('menu')).toHaveClass('ty-menu_vertical');
+      expect(screen.getByRole('menu')).toHaveClass('ty-menu_appearance-dropdown');
+    });
+  });
+
+  it('should treat marker-based menu overlays as menus', async () => {
+    const WrappedMenu = markComponent(
+      (props: React.ComponentProps<typeof Menu>) => <Menu {...props} />,
+      MENU_MARK
+    );
+
+    render(
+      <Dropdown
+        trigger="click"
+        overlay={
+          <WrappedMenu>
+            <Menu.Item>Menu Item</Menu.Item>
+          </WrappedMenu>
         }
       >
         <button>Trigger</button>

--- a/packages/react/src/dropdown/dropdown.tsx
+++ b/packages/react/src/dropdown/dropdown.tsx
@@ -1,5 +1,6 @@
 import React, { useCallback, useContext, useState } from 'react';
 import classNames from 'classnames';
+import { hasMarker, MENU_MARK } from '../_utils/component-markers';
 import { ConfigContext } from '../config-provider/config-context';
 import { getPrefixCls } from '../_utils/general';
 import { DropdownProps } from './types';
@@ -43,7 +44,7 @@ const Dropdown = (props: DropdownProps): JSX.Element => {
 
     const originalOnSelect = overlay.props.onSelect;
     const isMenuOverlay =
-      (overlay.type as React.ElementType & { displayName?: string }).displayName === 'Menu';
+      hasMarker(overlay.type, MENU_MARK);
 
     if (!isMenuOverlay) {
       return overlay;

--- a/packages/react/src/flip/__tests__/flip.test.tsx
+++ b/packages/react/src/flip/__tests__/flip.test.tsx
@@ -1,4 +1,6 @@
+import React from 'react';
 import { render } from '@testing-library/react';
+import { FLIP_ITEM_MARK, markComponent } from '../../_utils/component-markers';
 import Flip from '../index';
 
 describe('<Flip />', () => {
@@ -31,5 +33,22 @@ describe('<Flip />', () => {
     );
     expect(getByText('Front Side')).toBeInTheDocument();
     expect(getByText('Back Side')).toBeInTheDocument();
+  });
+
+  it('should recognize marker-based flip item wrappers', () => {
+    const WrappedItem = markComponent(
+      (props: React.ComponentProps<typeof Flip.Item>) => <Flip.Item {...props} />,
+      FLIP_ITEM_MARK
+    );
+
+    const { getByText } = render(
+      <Flip width={200} height={200}>
+        <WrappedItem><div>Front Wrapped</div></WrappedItem>
+        <WrappedItem><div>Back Wrapped</div></WrappedItem>
+      </Flip>
+    );
+
+    expect(getByText('Front Wrapped')).toBeInTheDocument();
+    expect(getByText('Back Wrapped')).toBeInTheDocument();
   });
 });

--- a/packages/react/src/flip/flip-item.tsx
+++ b/packages/react/src/flip/flip-item.tsx
@@ -1,4 +1,5 @@
 import { FlipItemProps } from './types';
+import { FLIP_ITEM_MARK, markComponent } from '../_utils/component-markers';
 
 const FlipItem = (props: FlipItemProps): JSX.Element => {
   const { className, children, ...otherProps } = props;
@@ -10,5 +11,6 @@ const FlipItem = (props: FlipItemProps): JSX.Element => {
 };
 
 FlipItem.displayName = 'FlipItem';
+markComponent(FlipItem, FLIP_ITEM_MARK);
 
 export default FlipItem;

--- a/packages/react/src/flip/flip.tsx
+++ b/packages/react/src/flip/flip.tsx
@@ -1,5 +1,6 @@
 import React, { useContext } from 'react';
 import classNames from 'classnames';
+import { FLIP_ITEM_MARK, hasMarker } from '../_utils/component-markers';
 import warning from '../_utils/warning';
 import { ConfigContext } from '../config-provider/config-context';
 import { getPrefixCls } from '../_utils/general';
@@ -39,7 +40,7 @@ const Flip = (props: FlipProps): React.ReactElement => {
       <div className={innerCls}>
         {React.Children.map(children, (child, index: number) => {
           const childElement = child as React.FunctionComponentElement<FlipItemProps>;
-          if (childElement.type.displayName === 'FlipItem') {
+          if (hasMarker(childElement.type, FLIP_ITEM_MARK)) {
             const childProps: Partial<FlipItemProps> = {
               className: classNames(
                 {

--- a/packages/react/src/input-number/input-number.tsx
+++ b/packages/react/src/input-number/input-number.tsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useState, MouseEvent, useContext } from 'react';
 import classNames from 'classnames';
+import { INPUT_GROUP_CONTROL_MARK, markComponent } from '../_utils/component-markers';
 import { ConfigContext } from '../config-provider/config-context';
 import { getPrefixCls } from '../_utils/general';
 import { InputNumberProps } from './types';
@@ -123,5 +124,6 @@ const InputNumber = React.forwardRef<HTMLDivElement, InputNumberProps>((props, r
 });
 
 InputNumber.displayName = 'InputNumber';
+markComponent(InputNumber, INPUT_GROUP_CONTROL_MARK);
 
 export default InputNumber;

--- a/packages/react/src/input/__tests__/input-group-addon.test.tsx
+++ b/packages/react/src/input/__tests__/input-group-addon.test.tsx
@@ -1,0 +1,57 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import Input from '../index';
+import Button from '../../button';
+import Select from '../../select';
+import InputNumber from '../../input-number';
+
+describe('<Input.Addon />', () => {
+  it('adds control styling and injects props into supported controls', () => {
+    const { container, rerender } = render(
+      <Input.Addon disabled size="lg">
+        <Input />
+      </Input.Addon>
+    );
+
+    expect(container.firstChild).toHaveClass('ty-input-group-addon_control', 'ty-input-group-addon_lg');
+    expect(container.querySelector('.ty-input')).toHaveClass('ty-input_lg', 'ty-input_disabled');
+    expect(container.querySelector('input')).toBeDisabled();
+
+    rerender(
+      <Input.Addon disabled size="lg">
+        <Button>Action</Button>
+      </Input.Addon>
+    );
+    expect(container.querySelector('.ty-btn')).toHaveClass('ty-btn_lg', 'ty-btn_disabled');
+    expect(container.querySelector('button')).toBeDisabled();
+
+    rerender(
+      <Input.Addon disabled size="lg">
+        <Select options={[{ label: 'One', value: '1' }]} />
+      </Input.Addon>
+    );
+    expect(container.querySelector('.ty-select')).toHaveClass('ty-select_lg', 'ty-select_disabled');
+
+    rerender(
+      <Input.Addon disabled size="lg">
+        <InputNumber />
+      </Input.Addon>
+    );
+    expect(container.querySelector('.ty-input-number')).toHaveClass(
+      'ty-input-number_lg',
+      'ty-input-number_disabled'
+    );
+    expect(container.querySelector('input[type="number"]')).toBeDisabled();
+  });
+
+  it('does not treat plain elements as input-group controls', () => {
+    const { container } = render(
+      <Input.Addon size="lg">
+        <span>plain text</span>
+      </Input.Addon>
+    );
+
+    expect(container.firstChild).not.toHaveClass('ty-input-group-addon_control');
+    expect(container.querySelector('span')).toHaveTextContent('plain text');
+  });
+});

--- a/packages/react/src/input/input-group-addon.tsx
+++ b/packages/react/src/input/input-group-addon.tsx
@@ -1,8 +1,9 @@
 import React, { useContext } from 'react';
 import classNames from 'classnames';
+import { hasMarker, INPUT_GROUP_CONTROL_MARK } from '../_utils/component-markers';
 import { ConfigContext } from '../config-provider/config-context';
 import { getPrefixCls } from '../_utils/general';
-import { InputGroupAddonProps, InputProps } from './types';
+import { InputGroupAddonProps, InputGroupControlProps } from './types';
 import { SizeType } from '../_utils/props';
 
 const InputGroupAddon = (props: InputGroupAddonProps): React.ReactElement => {
@@ -19,11 +20,7 @@ const InputGroupAddon = (props: InputGroupAddonProps): React.ReactElement => {
   const configContext = useContext(ConfigContext);
   const prefixCls = getPrefixCls('input-group-addon', configContext.prefixCls, customisedCls);
   const inputSize = props.size || configContext.componentSize || size;
-  const childDisplayName = React.isValidElement(children) ? (children.type as any)?.displayName : null;
-  const isControlChild = childDisplayName === 'Input'
-    || childDisplayName === 'Button'
-    || childDisplayName === 'Select'
-    || childDisplayName === 'InputNumber';
+  const isControlChild = React.isValidElement(children) && hasMarker(children.type, INPUT_GROUP_CONTROL_MARK);
   const cls = classNames(prefixCls, className, `${prefixCls}_${inputSize}`, {
     [`${prefixCls}_no-border`]: noBorder,
     [`${prefixCls}_control`]: isControlChild,
@@ -33,9 +30,8 @@ const InputGroupAddon = (props: InputGroupAddonProps): React.ReactElement => {
     return (
       <div className={cls} style={style}>
         {React.Children.map(children, (child: React.ReactElement) => {
-          const displayName = (child.type as any)?.displayName;
-          if (displayName === 'Input' || displayName === 'Button' || displayName === 'Select' || displayName === 'InputNumber') {
-            const childProps: Partial<InputProps> = {
+          if (hasMarker(child.type, INPUT_GROUP_CONTROL_MARK)) {
+            const childProps: Partial<InputGroupControlProps> = {
               disabled,
               size: inputSize as SizeType,
             };

--- a/packages/react/src/input/input.tsx
+++ b/packages/react/src/input/input.tsx
@@ -2,6 +2,7 @@ import React, { useEffect, useState, ReactNode, useContext } from 'react';
 import classNames from 'classnames';
 import { ConfigContext } from '../config-provider/config-context';
 import { getPrefixCls } from '../_utils/general';
+import { INPUT_GROUP_CONTROL_MARK, markComponent } from '../_utils/component-markers';
 import { CloseCircle } from '../_utils/components';
 import { InputProps } from './types';
 
@@ -95,5 +96,6 @@ const Input = React.forwardRef<HTMLInputElement, InputProps>(
 );
 
 Input.displayName = 'Input';
+markComponent(Input, INPUT_GROUP_CONTROL_MARK);
 
 export default Input;

--- a/packages/react/src/input/types.ts
+++ b/packages/react/src/input/types.ts
@@ -33,3 +33,8 @@ export interface InputGroupAddonProps
   size?: SizeType;
   children: React.ReactNode;
 }
+
+export interface InputGroupControlProps {
+  disabled?: boolean;
+  size?: SizeType;
+}

--- a/packages/react/src/menu/__tests__/menu.test.tsx
+++ b/packages/react/src/menu/__tests__/menu.test.tsx
@@ -1,5 +1,11 @@
 import React from 'react';
 import { render, fireEvent, screen, waitFor, act } from '@testing-library/react';
+import {
+  markComponent,
+  MENU_ITEM_GROUP_MARK,
+  MENU_ITEM_MARK,
+  SUB_MENU_MARK,
+} from '../../_utils/component-markers';
 import Menu from '../index';
 import ConfigProvider from '../../config-provider';
 
@@ -29,6 +35,40 @@ describe('<Menu />', () => {
       </Menu>
     );
     expect(container.firstChild).toHaveClass('ty-menu');
+  });
+
+  it('should recognize marker-based menu wrappers', async () => {
+    const WrappedItem = markComponent(
+      (props: React.ComponentProps<typeof Menu.Item>) => <Menu.Item {...props} />,
+      MENU_ITEM_MARK
+    );
+    const WrappedSubMenu = markComponent(
+      (props: React.ComponentProps<typeof Menu.SubMenu>) => <Menu.SubMenu {...props} />,
+      SUB_MENU_MARK
+    );
+    const WrappedGroup = markComponent(
+      (props: React.ComponentProps<typeof Menu.ItemGroup>) => <Menu.ItemGroup {...props} />,
+      MENU_ITEM_GROUP_MARK
+    );
+
+    render(
+      <Menu mode="vertical">
+        <WrappedSubMenu title="Parent">
+          <WrappedGroup title="Group">
+            <WrappedItem index="child">Child</WrappedItem>
+          </WrappedGroup>
+        </WrappedSubMenu>
+      </Menu>
+    );
+
+    fireEvent.mouseEnter(screen.getByText('Parent').closest('.ty-menu-sub') as HTMLElement);
+    act(() => {
+      jest.advanceTimersByTime(250);
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText('Child')).toBeInTheDocument();
+    });
   });
 
   it('should render items', () => {

--- a/packages/react/src/menu/menu-divider.tsx
+++ b/packages/react/src/menu/menu-divider.tsx
@@ -1,5 +1,6 @@
 import { useContext } from 'react';
 import classNames from 'classnames';
+import { markComponent, MENU_DIVIDER_MARK } from '../_utils/component-markers';
 import { ConfigContext } from '../config-provider/config-context';
 import { getPrefixCls } from '../_utils/general';
 import { BaseProps } from '../_utils/props';
@@ -14,5 +15,6 @@ const MenuDivider = (props: BaseProps): JSX.Element => {
 };
 
 MenuDivider.displayName = 'MenuDivider';
+markComponent(MenuDivider, MENU_DIVIDER_MARK);
 
 export default MenuDivider;

--- a/packages/react/src/menu/menu-item-group.tsx
+++ b/packages/react/src/menu/menu-item-group.tsx
@@ -1,5 +1,6 @@
 import React, { useContext } from 'react';
 import classNames from 'classnames';
+import { hasMarker, markComponent, MENU_ITEM_GROUP_MARK, MENU_ITEM_MARK } from '../_utils/component-markers';
 import { ConfigContext } from '../config-provider/config-context';
 import { getPrefixCls } from '../_utils/general';
 import { MenuItemGroupProps, MenuItemProps } from './types';
@@ -38,7 +39,7 @@ const MenuItemGroup = (props: MenuItemGroupProps): JSX.Element => {
       <ul className={`${prefixCls}__list`}>
         {React.Children.map(children, (child, idx) => {
           const childElement = child as React.FunctionComponentElement<MenuItemProps>;
-          if (childElement.type.displayName === 'MenuItem') {
+          if (hasMarker(childElement.type, MENU_ITEM_MARK)) {
             const popupGroupedStyle = mode !== 'inline'
               ? {
                   paddingLeft: 44,
@@ -65,5 +66,6 @@ const MenuItemGroup = (props: MenuItemGroupProps): JSX.Element => {
 };
 
 MenuItemGroup.displayName = 'MenuItemGroup';
+markComponent(MenuItemGroup, MENU_ITEM_GROUP_MARK);
 
 export default MenuItemGroup;

--- a/packages/react/src/menu/menu-item.tsx
+++ b/packages/react/src/menu/menu-item.tsx
@@ -1,5 +1,6 @@
 import React, { useContext, useLayoutEffect } from 'react';
 import classNames from 'classnames';
+import { markComponent, MENU_ITEM_MARK } from '../_utils/component-markers';
 import { MenuContext } from './menu-context';
 import { SubMenuContext } from './sub-menu-context';
 import { ConfigContext } from '../config-provider/config-context';
@@ -81,5 +82,6 @@ const MenuItem = (props: MenuItemProps): JSX.Element => {
 };
 
 MenuItem.displayName = 'MenuItem';
+markComponent(MenuItem, MENU_ITEM_MARK);
 
 export default MenuItem;

--- a/packages/react/src/menu/menu.tsx
+++ b/packages/react/src/menu/menu.tsx
@@ -1,5 +1,14 @@
 import React, { useCallback, useContext, useMemo, useRef, useState } from 'react';
 import classNames from 'classnames';
+import {
+  hasMarker,
+  markComponent,
+  MENU_DIVIDER_MARK,
+  MENU_ITEM_GROUP_MARK,
+  MENU_ITEM_MARK,
+  MENU_MARK,
+  SUB_MENU_MARK,
+} from '../_utils/component-markers';
 import { MenuContext } from './menu-context';
 import { ConfigContext } from '../config-provider/config-context';
 import { getPrefixCls } from '../_utils/general';
@@ -18,6 +27,12 @@ const getInitialSelectedKeys = (props: MenuProps): string[] => {
   return ['0'];
 };
 
+const isMenuStructureType = (type: unknown): boolean =>
+  hasMarker(type, MENU_ITEM_MARK) ||
+  hasMarker(type, SUB_MENU_MARK) ||
+  hasMarker(type, MENU_ITEM_GROUP_MARK) ||
+  hasMarker(type, MENU_DIVIDER_MARK);
+
 const collectParentMap = (
   children: React.ReactNode,
   ancestors: string[] = [],
@@ -33,32 +48,25 @@ const collectParentMap = (
     const childElement = child as React.FunctionComponentElement<
       MenuItemProps | MenuItemGroupProps | SubMenuProps
     >;
-    const displayName = childElement.type.displayName;
-
-    if (
-      displayName !== 'MenuItem' &&
-      displayName !== 'SubMenu' &&
-      displayName !== 'MenuItemGroup' &&
-      displayName !== 'MenuDivider'
-    ) {
+    if (!isMenuStructureType(childElement.type)) {
       return;
     }
 
     const fallbackIndex = parentIndex === undefined ? `${idx}` : `${parentIndex}-${idx}`;
     const resolvedIndex = childElement.props.index ?? fallbackIndex;
 
-    if (displayName === 'MenuItem' || displayName === 'SubMenu') {
+    if (hasMarker(childElement.type, MENU_ITEM_MARK) || hasMarker(childElement.type, SUB_MENU_MARK)) {
       parentMap.set(resolvedIndex, ancestors);
     }
 
-    if (displayName === 'SubMenu') {
+    if (hasMarker(childElement.type, SUB_MENU_MARK)) {
       const subMenuMap = collectParentMap(childElement.props.children, [...ancestors, resolvedIndex], resolvedIndex);
       subMenuMap.forEach((value, key) => {
         parentMap.set(key, value);
       });
     }
 
-    if (displayName === 'MenuItemGroup') {
+    if (hasMarker(childElement.type, MENU_ITEM_GROUP_MARK)) {
       const groupMap = collectParentMap(childElement.props.children, ancestors, resolvedIndex);
       groupMap.forEach((value, key) => {
         parentMap.set(key, value);
@@ -246,15 +254,14 @@ const Menu = (props: MenuProps): JSX.Element => {
       <MenuContext.Provider value={contextValue}>
         {React.Children.map(children, (child, index) => {
           const childElement = child as React.FunctionComponentElement<MenuItemProps>;
-          const { displayName } = childElement.type;
           if (
-            displayName === 'MenuItem' ||
-            displayName === 'SubMenu' ||
-            displayName === 'MenuItemGroup' ||
-            (displayName === 'MenuDivider' && mode !== 'horizontal')
+            hasMarker(childElement.type, MENU_ITEM_MARK) ||
+            hasMarker(childElement.type, SUB_MENU_MARK) ||
+            hasMarker(childElement.type, MENU_ITEM_GROUP_MARK) ||
+            (hasMarker(childElement.type, MENU_DIVIDER_MARK) && mode !== 'horizontal')
           ) {
             const resolvedIndex = childElement.props.index ?? `${index}`;
-            const childProps = displayName === 'SubMenu' && overlayClassName
+            const childProps = hasMarker(childElement.type, SUB_MENU_MARK) && overlayClassName
               ? { index: resolvedIndex, overlayClassName }
               : { index: resolvedIndex };
             return React.cloneElement(childElement, childProps);
@@ -269,5 +276,6 @@ const Menu = (props: MenuProps): JSX.Element => {
 };
 
 Menu.displayName = 'Menu';
+markComponent(Menu, MENU_MARK);
 
 export default Menu;

--- a/packages/react/src/menu/sub-menu.tsx
+++ b/packages/react/src/menu/sub-menu.tsx
@@ -1,5 +1,13 @@
 import React, { useContext, useEffect, useLayoutEffect, useState, useRef } from 'react';
 import classNames from 'classnames';
+import {
+  hasMarker,
+  markComponent,
+  MENU_DIVIDER_MARK,
+  MENU_ITEM_GROUP_MARK,
+  MENU_ITEM_MARK,
+  SUB_MENU_MARK,
+} from '../_utils/component-markers';
 import { MenuContext } from './menu-context';
 import { SubMenuContext } from './sub-menu-context';
 import { ArrowDown } from '../_utils/components';
@@ -139,15 +147,14 @@ const SubMenu = (props: SubMenuProps): JSX.Element => {
       <ul className={subMenuCls} style={{ minWidth }}>
         {React.Children.map(children, (child, idx) => {
           const childElement = child as React.FunctionComponentElement<MenuItemProps>;
-          const { displayName } = childElement.type;
           const childProps = {
             index: childElement.props.index ?? `${index}-${idx}`,
           };
           if (
-            displayName === 'MenuItem' ||
-            displayName === 'MenuItemGroup' ||
-            displayName === 'SubMenu' ||
-            displayName === 'MenuDivider'
+            hasMarker(childElement.type, MENU_ITEM_MARK) ||
+            hasMarker(childElement.type, MENU_ITEM_GROUP_MARK) ||
+            hasMarker(childElement.type, SUB_MENU_MARK) ||
+            hasMarker(childElement.type, MENU_DIVIDER_MARK)
           ) {
             return React.cloneElement(childElement, childProps);
           } else {
@@ -229,5 +236,6 @@ const SubMenu = (props: SubMenuProps): JSX.Element => {
 };
 
 SubMenu.displayName = 'SubMenu';
+markComponent(SubMenu, SUB_MENU_MARK);
 
 export default SubMenu;

--- a/packages/react/src/select/__tests__/select.test.tsx
+++ b/packages/react/src/select/__tests__/select.test.tsx
@@ -1,4 +1,6 @@
+import React from 'react';
 import { render, fireEvent, screen, waitFor, act } from '@testing-library/react';
+import { markComponent, SELECT_OPT_GROUP_MARK, SELECT_OPTION_MARK } from '../../_utils/component-markers';
 import Select from '../index';
 
 const { Option, OptGroup } = Select;
@@ -32,6 +34,28 @@ describe('<Select />', () => {
       </Select>
     );
     expect(container.firstChild).toHaveClass('ty-select');
+  });
+
+  it('should recognize marker-based option wrappers', () => {
+    const WrappedOption = markComponent(
+      (props: React.ComponentProps<typeof Option>) => <Option {...props} />,
+      SELECT_OPTION_MARK
+    );
+    const WrappedGroup = markComponent(
+      (props: React.ComponentProps<typeof OptGroup>) => <OptGroup {...props} />,
+      SELECT_OPT_GROUP_MARK
+    );
+
+    render(
+      <Select defaultOpen>
+        <WrappedGroup label="Group A">
+          <WrappedOption value="a">Apple</WrappedOption>
+        </WrappedGroup>
+      </Select>
+    );
+
+    expect(getOptions()).toHaveLength(1);
+    expect(getOptions()[0]).toHaveTextContent('Apple');
   });
 
   // Single select

--- a/packages/react/src/select/opt-group.tsx
+++ b/packages/react/src/select/opt-group.tsx
@@ -1,5 +1,6 @@
 import React, { useContext } from 'react';
 import classNames from 'classnames';
+import { hasMarker, markComponent, SELECT_OPT_GROUP_MARK, SELECT_OPTION_MARK } from '../_utils/component-markers';
 import { ConfigContext } from '../config-provider/config-context';
 import { getPrefixCls } from '../_utils/general';
 import { SelectOptGroupProps, SelectOptionsProps } from './types';
@@ -16,7 +17,7 @@ const SelectOptGroup = (props: SelectOptGroupProps): React.ReactElement => {
       <ul className={`${prefixCls}__list`}>
         {React.Children.map(children, (child) => {
           const childElement = child as React.FunctionComponentElement<SelectOptionsProps>;
-          if (childElement.type.displayName === 'SelectOption') {
+          if (hasMarker(childElement.type, SELECT_OPTION_MARK)) {
             const childProps = {
               ...childElement.props,
             };
@@ -34,5 +35,6 @@ const SelectOptGroup = (props: SelectOptGroupProps): React.ReactElement => {
 };
 
 SelectOptGroup.displayName = 'SelectOptGroup';
+markComponent(SelectOptGroup, SELECT_OPT_GROUP_MARK);
 
 export default SelectOptGroup;

--- a/packages/react/src/select/option.tsx
+++ b/packages/react/src/select/option.tsx
@@ -1,6 +1,7 @@
 import React, { useContext, useState } from 'react';
 import classNames from 'classnames';
 import { Check } from '../_utils/components';
+import { markComponent, SELECT_OPTION_MARK } from '../_utils/component-markers';
 import { SelectContext } from './select-context';
 import { ConfigContext } from '../config-provider/config-context';
 import { getPrefixCls } from '../_utils/general';
@@ -58,5 +59,6 @@ const SelectOption = (props: SelectOptionsProps): React.ReactElement => {
 };
 
 SelectOption.displayName = 'SelectOption';
+markComponent(SelectOption, SELECT_OPTION_MARK);
 
 export default SelectOption;

--- a/packages/react/src/select/select.tsx
+++ b/packages/react/src/select/select.tsx
@@ -1,5 +1,13 @@
 import React, { useContext, useEffect, useId, useRef, useState, useCallback, useMemo } from 'react';
 import classNames from 'classnames';
+import {
+  hasMarker,
+  INPUT_GROUP_CONTROL_MARK,
+  markComponent,
+  SELECT_MARK,
+  SELECT_OPT_GROUP_MARK,
+  SELECT_OPTION_MARK,
+} from '../_utils/component-markers';
 import { useCombobox } from '../_utils/useCombobox';
 import { ArrowDown, Close, CloseCircle, LoadingCircle, Check } from '../_utils/components';
 import { SelectContext } from './select-context';
@@ -79,13 +87,13 @@ const Select = (props: SelectProps): React.ReactElement => {
       React.Children.forEach(nodes, (child) => {
         const el = child as React.FunctionComponentElement<SelectOptionsProps>;
         if (!el?.type) return;
-        if (el.type.displayName === 'SelectOption') {
+        if (hasMarker(el.type, SELECT_OPTION_MARK)) {
           result.push({
             value: el.props.value,
             label: el.props.label ?? el.props.children,
             disabled: !!el.props.disabled,
           });
-        } else if (el.type.displayName === 'SelectOptGroup') {
+        } else if (hasMarker(el.type, SELECT_OPT_GROUP_MARK)) {
           extractFromChildren(el.props.children);
         }
       });
@@ -353,7 +361,7 @@ const Select = (props: SelectProps): React.ReactElement => {
     return React.Children.map(nodes, (child) => {
       const el = child as React.FunctionComponentElement<SelectOptionsProps>;
       if (!el?.type) return null;
-      if (el.type.displayName === 'SelectOption') {
+      if (hasMarker(el.type, SELECT_OPTION_MARK)) {
         const opt: SelectOptionItem = {
           value: el.props.value,
           label: el.props.label ?? el.props.children,
@@ -362,7 +370,7 @@ const Select = (props: SelectProps): React.ReactElement => {
         if (!combo.matchesFilter(opt)) return null;
         return React.cloneElement(el, el.props);
       }
-      if (el.type.displayName === 'SelectOptGroup') {
+      if (hasMarker(el.type, SELECT_OPT_GROUP_MARK)) {
         const filteredGroupChildren = filterChildren(el.props.children);
         const hasVisibleChildren = React.Children.toArray(filteredGroupChildren).some(Boolean);
         if (!hasVisibleChildren) return null;
@@ -585,5 +593,7 @@ const Select = (props: SelectProps): React.ReactElement => {
 };
 
 Select.displayName = 'Select';
+markComponent(Select, INPUT_GROUP_CONTROL_MARK);
+markComponent(Select, SELECT_MARK);
 
 export default Select;

--- a/packages/react/src/steps/__tests__/steps.test.tsx
+++ b/packages/react/src/steps/__tests__/steps.test.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { render } from '@testing-library/react';
+import { markComponent, STEPS_ITEM_MARK } from '../../_utils/component-markers';
 import Steps from '../index';
 
 describe('<Steps />', () => {
@@ -32,5 +33,20 @@ describe('<Steps />', () => {
     );
     expect(getByText('First')).toBeInTheDocument();
     expect(getByText('Second')).toBeInTheDocument();
+  });
+
+  it('should recognize marker-based step wrappers', () => {
+    const WrappedStep = markComponent(
+      (props: React.ComponentProps<typeof Steps.Step>) => <Steps.Step {...props} />,
+      STEPS_ITEM_MARK
+    );
+
+    const { getByText } = render(
+      <Steps current={0}>
+        <WrappedStep title="Wrapped Step" />
+      </Steps>
+    );
+
+    expect(getByText('Wrapped Step')).toBeInTheDocument();
   });
 });

--- a/packages/react/src/steps/steps-item.tsx
+++ b/packages/react/src/steps/steps-item.tsx
@@ -1,5 +1,6 @@
 import React, { useContext, ReactNode } from 'react';
 import classNames from 'classnames';
+import { markComponent, STEPS_ITEM_MARK } from '../_utils/component-markers';
 import { ConfigContext } from '../config-provider/config-context';
 import { getPrefixCls } from '../_utils/general';
 import { StepsContext } from './steps-context';
@@ -99,5 +100,6 @@ const StepsItem = React.forwardRef<HTMLDivElement, StepsItemProps>(
 );
 
 StepsItem.displayName = 'StepsItem';
+markComponent(StepsItem, STEPS_ITEM_MARK);
 
 export default StepsItem;

--- a/packages/react/src/steps/steps.tsx
+++ b/packages/react/src/steps/steps.tsx
@@ -1,5 +1,6 @@
 import React, { useContext, useEffect, useState } from 'react';
 import classNames from 'classnames';
+import { hasMarker, STEPS_ITEM_MARK } from '../_utils/component-markers';
 import { ConfigContext } from '../config-provider/config-context';
 import { getPrefixCls } from '../_utils/general';
 import { StepsContext } from './steps-context';
@@ -46,7 +47,7 @@ const Steps = React.forwardRef<HTMLDivElement, StepsProps>(
         <div {...otherProps} ref={ref} className={cls}>
           {React.Children.map(children, (child, idx) => {
             const childElement = child as React.FunctionComponentElement<StepsItemProps>;
-            if (childElement.type.displayName === 'StepsItem') {
+            if (hasMarker(childElement.type, STEPS_ITEM_MARK)) {
               const childProps: Partial<StepsItemProps> = {
                 stepIndex: idx,
               };

--- a/packages/react/src/timeline/__tests__/timeline.test.tsx
+++ b/packages/react/src/timeline/__tests__/timeline.test.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { render } from '@testing-library/react';
+import { markComponent, TIMELINE_ITEM_MARK } from '../../_utils/component-markers';
 import Timeline from '../index';
 
 describe('<Timeline />', () => {
@@ -31,5 +32,20 @@ describe('<Timeline />', () => {
     );
     expect(getByText('Event 1')).toBeInTheDocument();
     expect(getByText('Event 2')).toBeInTheDocument();
+  });
+
+  it('should recognize marker-based timeline item wrappers', () => {
+    const WrappedItem = markComponent(
+      (props: React.ComponentProps<typeof Timeline.Item>) => <Timeline.Item {...props} />,
+      TIMELINE_ITEM_MARK
+    );
+
+    const { getByText } = render(
+      <Timeline>
+        <WrappedItem>Wrapped Event</WrappedItem>
+      </Timeline>
+    );
+
+    expect(getByText('Wrapped Event')).toBeInTheDocument();
   });
 });

--- a/packages/react/src/timeline/timeline-item.tsx
+++ b/packages/react/src/timeline/timeline-item.tsx
@@ -1,5 +1,6 @@
 import React, { useContext } from 'react';
 import classNames from 'classnames';
+import { markComponent, TIMELINE_ITEM_MARK } from '../_utils/component-markers';
 import { ConfigContext } from '../config-provider/config-context';
 import { getPrefixCls } from '../_utils/general';
 import { TimelineItemProps } from './types';
@@ -23,5 +24,6 @@ const TimelineItem = React.forwardRef<HTMLLIElement, TimelineItemProps>((props, 
 });
 
 TimelineItem.displayName = 'TimelineItem';
+markComponent(TimelineItem, TIMELINE_ITEM_MARK);
 
 export default TimelineItem;

--- a/packages/react/src/timeline/timeline.tsx
+++ b/packages/react/src/timeline/timeline.tsx
@@ -1,5 +1,6 @@
 import React, { useContext } from 'react';
 import classNames from 'classnames';
+import { hasMarker, TIMELINE_ITEM_MARK } from '../_utils/component-markers';
 import { ConfigContext } from '../config-provider/config-context';
 import { getPrefixCls } from '../_utils/general';
 import { TimelineItemProps, TimelineProps } from './types';
@@ -16,7 +17,7 @@ const Timeline = React.forwardRef<HTMLUListElement, TimelineProps>((props, ref) 
     <ul {...otherProps} ref={ref} className={cls}>
       {React.Children.map(children, (child, idx) => {
         const childElement = child as React.FunctionComponentElement<TimelineItemProps>;
-        if (childElement.type.displayName === 'TimelineItem') {
+        if (hasMarker(childElement.type, TIMELINE_ITEM_MARK)) {
           const childProps: Partial<TimelineItemProps> = {
             className:
               position === 'center'


### PR DESCRIPTION
## Summary
- replace runtime displayName checks in React component composition paths with symbol-based markers
- keep displayName for debugging while adding shared marker helpers and marker-based regression tests
- add a patch changeset for @tiny-design/react

## Release
- patch: @tiny-design/react

## Test plan
- pnpm --filter @tiny-design/react test -- "button|input"
- pnpm --filter @tiny-design/react test -- "select|menu|dropdown|anchor|steps|timeline|card|flip|avatar|input"
- pnpm --filter @tiny-design/react test